### PR TITLE
docs(#1368, #1369, #1374): Hetzner/Postgres/Sequin migration docs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -33,5 +33,5 @@
 
 - `.agents/skills/add-backend-lambda/SKILL.md` — add Lambda workflow.
 - `.agents/skills/add-entity-type/SKILL.md` — add entity/type workflow.
-- `.agents/skills/autonomously-push-changes/SKILL.md` — GitHub issue, branch, push, and PR workflow.
+- `.agents/skills/github-workflow/SKILL.md` — GitHub issue, branch, push, and PR workflow.
 - `.agents/skills/add-rest-api-endpoint/SKILL.md` — add REST endpoint workflow.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -33,4 +33,5 @@
 
 - `.agents/skills/add-backend-lambda/SKILL.md` — add Lambda workflow.
 - `.agents/skills/add-entity-type/SKILL.md` — add entity/type workflow.
+- `.agents/skills/autonomously-push-changes/SKILL.md` — GitHub issue, branch, push, and PR workflow.
 - `.agents/skills/add-rest-api-endpoint/SKILL.md` — add REST endpoint workflow.

--- a/.agents/skills/add-backend-lambda/SKILL.md
+++ b/.agents/skills/add-backend-lambda/SKILL.md
@@ -1,31 +1,70 @@
 ---
 name: add-backend-lambda
-description: Use when adding a new AWS Lambda to the Aura Historia Rust backend. Covers crate placement, handler/bootstrap shape, infra wiring, queue/EventBridge/API triggers, LocalStack/test wiring, docs, and validation.
+description: Use only when adding or changing an AWS-survivor Lambda in the Aura Historia backend. Prefer `aura-historia-api` for REST work and `aura-historia-worker` for migrated async business work. Covers survivor boundaries, handler/bootstrap shape, infra wiring, LocalStack/test wiring, docs, and validation.
 ---
 
 # Add Backend Lambda
 
-Use this skill when the task adds a new Lambda binary or a new Lambda worker flow.
-If the task is only adding a route to an existing `*-api` Lambda, use `add-rest-api-endpoint` instead.
+Use this skill only for AWS Lambda work that remains inside the hybrid Hetzner/AWS target.
+
+Do **not** add a Lambda for migrated business flows. Prefer:
+
+- `aura-historia-api` for REST routes. Use `add-rest-api-endpoint`.
+- `aura-historia-worker` for async business jobs driven by Postgres/Sequin.
+- Postgres repositories for migrated business state.
 
 ## First checks
 
 - Read the required `AGENTS.md` chain: repo root, `src/AGENTS.md`, `infra/AGENTS.md`, and the nearest crate docs.
+- Read target architecture docs when the change touches storage or events:
+  - `docs/hetzner_postgres_sequin_migration.md`
+  - `docs/storage.md`
+  - `docs/events/flow.md`
+- Confirm this is an AWS survivor Lambda before editing.
 - Find similar Lambdas before designing. Good samples:
-  - API Lambda bootstrap: `src/product-api/src/main.rs`
   - SQS worker: `src/product-lambda/src/product-lambda-ingest-partner-products/`
   - EventBridge worker: `src/stripe-lambda/`
   - Infra maps: `infra/src/constructs/lambdas.ts`, `queues.ts`, `eventing.ts`
-- Decide the trigger and retry contract first: API Gateway, SQS, EventBridge partner bus, DynamoDB stream via EventBridge+SQS, schedule, or direct invoke.
+- Decide trigger and retry contract first: SQS, EventBridge partner bus, DynamoDB stream via EventBridge+SQS, schedule, or direct invoke.
+
+## Allowed Lambda scope
+
+Allowed new/changed Lambda work should fit one of these survivor areas:
+
+- notification insert-to-send workflow using DynamoDB + `notification-send` + SES/S3 templates
+- Shopify AWS intake, writing product rows/events to Postgres synchronously
+- Stripe AWS intake, writing user/subscription state to Postgres synchronously
+- Step Functions task Lambda for partner-shop-application workflow, writing Postgres directly
+- FX rate scheduled Lambda using DynamoDB as survivor storage
+- OAuth clients/codes/access-token DynamoDB flows
+- Cognito integration that cannot move into `aura-historia-api`
+- CloudWatch log-retention utility
+- infra/test glue for survivor Lambdas
+
+If the flow is product projection, percolation, user tier enforcement, product enrichment, shop/search-filter OpenSearch sync, or periodic matcher, prefer `aura-historia-worker` unless the user explicitly asks for AWS-survivor behavior.
+
+## Target storage rules
+
+- Postgres owns migrated business truth: users, shops, partner applications, products, product events, watchlist, search filters, and search-filter matches.
+- DynamoDB keeps notifications, access tokens, OAuth clients/codes, and FX rate.
+- OpenSearch is rebuildable projection only.
+- No users OpenSearch index in target design.
+- No Postgres `access_tokens` or `access_token_scopes`.
+- No worker-owned Postgres tables: no `worker_inbox`, `worker_processed_jobs`, `worker_dead_letters`, or `worker_schedules`.
+- No scheduled inconsistency checker or repair job for MVP.
+- Crawler is out of scope.
+
+AWS survivor Lambdas that need migrated business data connect to Postgres directly. Do not call internal `aura-historia-api` as a data bridge.
 
 ## Choose crate location
 
-- Prefer an existing grouped parent when the worker belongs to an existing domain:
+- Prefer an existing grouped parent when the worker belongs to an existing survivor domain:
   - child crate path: `src/<domain>-lambda/src/<binary-name>/`
   - examples: `product-lambda-*`, `search-filter-lambda-*`, `user-lambda-*`
 - Use a top-level `src/<name>-lambda/` crate only when no existing parent fits or the Lambda is a standalone integration.
-- Name the Cargo package and deployed binary in kebab-case, e.g. `product-lambda-rebuild-foo`.
+- Name the Cargo package and deployed binary in kebab-case, e.g. `shopify-lambda-sync-product`.
 - Add or update an `AGENTS.md` at the crate root. For child crates, also update the parent Lambda `AGENTS.md` child index.
+- Do not create new API Gateway adapter Lambdas for migrated API routes.
 
 ## Rust workspace wiring
 
@@ -41,6 +80,7 @@ Update only the files the new crate needs:
 - New crate `Cargo.toml`
   - use workspace dependencies
   - enable event features explicitly, e.g. `aws_lambda_events = { workspace = true, features = ["sqs"] }`
+  - use `common::postgres` / existing Postgres helpers when writing migrated business data
   - keep dev-dependencies targeted: `fake`, `rstest`, `serial_test`, `test-api`, and domain `test-data` features only when needed
 
 ## Handler shape
@@ -56,6 +96,19 @@ Update only the files the new crate needs:
 - Add `#[tracing::instrument(skip(...), fields(requestId = %event.context.request_id, ...))]` on handlers.
 - Keep logs compact and structured. Do not log PII, secrets, raw tokens, or full payloads unless the payload is known safe.
 - Do not hide business rules in Lambda glue. Put reusable behavior into the domain/service crate.
+- When writing Postgres, use repositories/DAOs. Do not operate directly on SQL rows outside adapter boundaries.
+
+## Postgres access from AWS Lambda
+
+When a survivor Lambda writes or reads migrated business data:
+
+- Use TLS to Postgres.
+- Load credentials from AWS SSM/Secrets Manager or equivalent secret source.
+- Keep Lambda connection pools very small.
+- Add PgBouncer or equivalent if concurrency can exceed safe Postgres connections.
+- Restrict network path by allowlist, VPN, tunnel, private overlay, or another reviewed control.
+- Monitor failed connects, connection count, pool wait, and auth failures.
+- Product writes must synchronously insert `product_events` and update `products` in one transaction. No product command buffer and no `202 accepted because queued` semantics.
 
 ## Event and retry rules
 
@@ -67,6 +120,7 @@ Update only the files the new crate needs:
   - return a batch item failure if it should go to the DLQ
   - log and skip only when retry cannot help and the event is safe to drop
 - Keep handlers idempotent. Assume duplicate delivery.
+- Prefer domain IDs for idempotency. Avoid coupling business idempotency to SQS message IDs.
 - Pick batch size, concurrency, and visibility timeout together. Visibility timeout must exceed Lambda timeout; heavy queue workers usually use about `6x` timeout unless there is a reason not to.
 
 ### EventBridge workers
@@ -76,11 +130,18 @@ Update only the files the new crate needs:
 - Return an error only for retryable failures.
 - Document source bus, event pattern, side effects, and idempotency.
 
+### DynamoDB stream workers
+
+- Only use for survivor DynamoDB flows, such as notification send.
+- Do not add DynamoDB streams for migrated Postgres business tables.
+- Keep payload mapping at the edge. Pass domain types into reusable services.
+
 ### Scheduled workers
 
 - Keep schedules in `infra/src/constructs/eventing.ts` or a focused construct.
 - Fail fast. Avoid long timeout camping.
 - Skip ephemeral stage when the job depends on real third-party state.
+- Do not add a scheduled inconsistency checker/repair job for the worker MVP unless the architecture decision changes.
 
 ## Infra wiring
 
@@ -89,8 +150,10 @@ Update `infra/` in the same change when adding trigger, env var, IAM, queue, rou
 - `infra/src/constructs/lambdas.ts`
   - add a `LAMBDA_DEFINITIONS` entry with stable `id`, `binaryName`, memory, timeout, and environment
   - include stage-specific secrets via SSM helpers; use test values for ephemeral when needed
-  - update `grantRuntimeAccess` lists for DynamoDB (default), OpenSearch, S3/SES, queue send, or other resource access
+  - add Postgres env/secret wiring when the survivor Lambda writes migrated business data
+  - update `grantRuntimeAccess` lists for DynamoDB, OpenSearch, S3/SES, queue send, or other resource access
   - update `addUserPoolEnvironment` / `grantCognitoAdminAccess` if Cognito is used
+  - keep CloudWatch log-retention utility wiring
 - `infra/src/constructs/queues.ts` for SQS-backed workers:
   - add main queue + DLQ definition
   - choose `maxReceiveCount`, `visibilityTimeoutSeconds`, and SSE intentionally
@@ -102,11 +165,16 @@ Update `infra/` in the same change when adding trigger, env var, IAM, queue, rou
   - add CloudFormation outputs only when tests, users, or tooling really need them
 - Run or update infra tests when stack shape changes.
 
+Do not add API Gateway routes for migrated API work. CloudFront fronts `aura-historia-api`, not new API Lambdas.
+
 ## Test and LocalStack wiring
 
 - Unit-test handler behavior with mocks. Cover happy path, invalid payload, downstream error, retry/drop decision, and idempotency edge cases.
 - Add integration tests for repository or AWS adapter code touched by the Lambda.
-- Add acceptance tests for critical event flows. Every lambda should be invoked (indirectly downstream most often) in at least one acceptance test.
+- Use `test-api` Postgres helpers for Postgres repositories or direct Lambda-to-Postgres integration tests.
+- Use existing LocalStack OpenSearch for OpenSearch tests. Do not add a standalone OpenSearch container.
+- Keep DynamoDB and CDK/CloudFormation helpers for survivor tests.
+- Add acceptance tests for critical survivor event flows. Every survivor Lambda should be invoked indirectly downstream in at least one acceptance test when practical.
 - Update LocalStack/cloud wiring when the Lambda participates in deployed tests:
   - `src/test-api/src/cloudformation.rs` `LAMBDA_BINARIES`
   - queue drain list in `src/test-api/src/cloudformation.rs` when a queue is added
@@ -121,9 +189,11 @@ Update docs in the same change when behavior changes:
 - nearest crate `AGENTS.md`: purpose, modules, env vars, event shape, side effects, verification
 - parent `AGENTS.md` child index for new child crates
 - `src/AGENTS.md` child index for new top-level crates
-- `docs/events/flow.md` for event-driven flow changes
-- `docs/dynamodb/table_1.md` for DynamoDB structure changes
+- `docs/events/flow.md` for survivor event-flow changes
+- `docs/storage.md` for storage ownership changes
+- `docs/dynamodb/table_1.md` for DynamoDB survivor structure changes
 - OpenSearch mappings under `opensearch/mappings` if DTO/index shape changes
+- infra docs if deployment, env vars, or IAM shape changes
 
 ## Validation
 

--- a/.agents/skills/autonomously-push-changes/SKILL.md
+++ b/.agents/skills/autonomously-push-changes/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: autonomously-push-changes
+description: Use when asked to autonomously create GitHub issues, start issue work, push branches, or open pull requests in the Aura Historia backend. Covers branch names, issue/project fields, PR titles/descriptions, and state transitions.
+---
+
+# Autonomously Push Changes
+
+Use this skill when the user asks you to work with GitHub, not just local files.
+
+Never commit to `develop`. Never merge a pull request.
+
+## First checks
+
+- Read the relevant `AGENTS.md` chain first.
+- Check git state before editing:
+  - `git --no-pager status --short`
+  - `git --no-pager branch --show-current`
+- Do not overwrite or commit user changes you did not make.
+- Check remote/issue/PR state before creating duplicates.
+- Prefer `gh` for GitHub work.
+
+## Branch naming
+
+Use no `#` in branch names.
+
+For normal issues:
+
+```text
+{task|feat|epic|docs|fix|deps}/{ISSUE_NUMBER}-short-title
+```
+
+For issues with a parent:
+
+```text
+{task|feat|epic|docs|fix|deps}/{PARENT_ISSUE_NUMBER}-short-title-parent/{task|feat|epic|docs|fix|deps}/{ISSUE_NUMBER}-short-title
+```
+
+Examples:
+
+```text
+epic/1341-hetzner-postgres-sequin-migration
+docs/1341-hetzner-postgres-sequin-migration-parent/docs/1368-adr-draft
+task/1341-hetzner-postgres-sequin-migration-parent/task/1371-api-runtime
+fix/1450-token-validation
+```
+
+Rules:
+
+- Use lowercase kebab-case.
+- Keep short title stable and clear.
+- Use `epic/` only for epic base branches.
+- Use `docs/` for docs-only work.
+- Use `deps/` for dependency-only work.
+- Use `fix/` for bug fixes.
+- Use `feat/` for user-visible feature work.
+- Use `task/` for internal implementation work.
+
+## Creating issues
+
+When asked to create issues:
+
+- Search existing issues first.
+- Create small, parallelizable issues where possible.
+- Link to parent epic when given.
+- Add issues to project `Backend`.
+- Set project state to `Todo` unless user says otherwise.
+- Set sensible project priority.
+- Set relevant labels and issue type.
+- Keep issue body actionable and scoped.
+
+Issue body template:
+
+```md
+Parent epic: #<parent>
+
+## Priority
+
+<Priority>
+
+## Goal
+
+<One clear outcome.>
+
+## Scope
+
+- <Included work>
+- <Included work>
+
+## Out of scope
+
+- <Explicit non-work if useful>
+
+## Must inspect
+
+- `<path>`
+
+## Acceptance criteria
+
+- <Observable done state>
+- <Tests/docs updated where needed>
+
+## Validation
+
+- `<command>`
+```
+
+Good issue description:
+
+- says why, what, and done
+- names key paths
+- states dependencies/blockers
+- states out-of-scope traps
+- gives validation commands
+- avoids vague words like “improve” without measurable outcome
+
+## Starting work on issues
+
+When starting an issue:
+
+- Assign yourself if GitHub identity is available.
+- Move issue project state to `In Progress`.
+- Create branch from the correct base:
+  - epic issue: from `develop` unless user gives other base
+  - child issue: from parent epic branch when one exists
+  - normal issue: from `develop` unless user gives other base
+- Push branch early if a PR will be opened.
+- Comment on the issue only when useful; avoid noise.
+
+## Commits and pushing
+
+- Commit focused changes with clear messages.
+- Do not amend/rebase public work unless safe and useful.
+- Push to origin branch.
+- Keep generated temp files out of commits.
+- If working tree contains user changes, commit only your files.
+
+Commit message examples:
+
+```text
+docs(1368): draft Hetzner migration ADR
+task(1371): add API runtime skeleton
+fix(1450): handle missing token subject
+deps(1460): bump sqlx
+```
+
+## Creating pull requests
+
+PR title format:
+
+```text
+{task|feat|epic|docs|fix|deps}({ISSUE_NUMBER}): short-title
+```
+
+Examples:
+
+```text
+docs(1368): draft migration ADR
+task(1371): add API runtime skeleton
+fix(1450): reject malformed tokens
+```
+
+PR rules:
+
+- Target the issue's base branch.
+- Link issue in PR body.
+- Move issue project state to `In Review`.
+- Do not merge.
+- Mark draft only when work is intentionally not ready for review.
+
+PR body template:
+
+```md
+Closes #<issue>
+Parent: #<parent-if-any>
+
+## Intent
+
+<Why this change exists.>
+
+## Summary
+
+- <Changed thing>
+- <Changed thing>
+
+## Breaking changes
+
+- <None, or exact break/migration need.>
+
+## Behavior impact
+
+- <Runtime/API/storage/event impact.>
+
+## Risk
+
+- <Main risk and mitigation.>
+
+## Validation
+
+- `<command>`
+```
+
+Good PR description:
+
+- says intent, not just file list
+- lists breaking changes explicitly, even as `None`
+- calls out API/storage/event/infra behavior changes
+- includes validation actually run
+- notes skipped validation with reason
+- links issue and parent epic
+- gives reviewer focus when helpful
+
+## Project fields
+
+When creating or moving issues, keep GitHub project `Backend` aligned:
+
+- new issue: `Todo`
+- started work: `In Progress`
+- PR opened: `In Review`
+- done/merged: do not move unless user asks or repo convention requires it
+
+Set priority sensibly:
+
+- `Critical`: blocks many tasks, architecture, data loss/security risk, release blocker
+- `High`: core feature path or important migration slice
+- `Medium`: useful implementation slice, not blocking most work
+- `Low`: cleanup, docs polish, follow-up
+
+Set labels/type from repo conventions. If unsure:
+
+- inspect similar issues first
+- choose minimal labels
+- do not invent labels unless requested
+
+## GitHub commands
+
+Use `gh` safely:
+
+```sh
+gh issue list --repo aura-historia/backend --search "..."
+gh issue create --repo aura-historia/backend --title "..." --body-file file.md
+gh issue edit <number> --repo aura-historia/backend --add-label "..."
+gh pr create --repo aura-historia/backend --base "..." --head "..." --title "..." --body-file file.md
+gh pr view <number> --repo aura-historia/backend --json number,title,url,state
+```
+
+For project fields, inspect existing project item shape first and update with `gh project item-edit` or GraphQL as needed.
+
+## Validation
+
+Before final response:
+
+- Confirm pushed branch and PR URL if created.
+- Confirm issue state changes if made.
+- Confirm validation commands run.
+- Confirm PR not merged.
+- Mention any uncommitted user changes left untouched.

--- a/.agents/skills/github-workflow/SKILL.md
+++ b/.agents/skills/github-workflow/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: autonomously-push-changes
+name: github-workflow
 description: Use when asked to autonomously create GitHub issues, start issue work, push branches, or open pull requests in the Aura Historia backend. Covers branch names, issue/project fields, PR titles/descriptions, and state transitions.
 ---
 
-# Autonomously Push Changes
+# GitHub Workflow
 
 Use this skill when the user asks you to work with GitHub, not just local files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - Less is more.
 - Keep docs short, clear, current.
 - In `src`, make doc by crate. No module doc unless module become crate boundary.
-- When instructed to autonomously create issues or push changes to GitHub, refer to `.agents/autonomously-push-changes` for guidance. If no guidance exists, do not create issues or push changes. Never ever commit to develop branch or merge a pull request.
+- When instructed to autonomously create issues or push changes to GitHub, refer to `.agents/skills/github-workflow` for guidance. If no guidance exists, do not create issues or push changes. Never ever commit to develop branch or merge a pull request.
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - Less is more.
 - Keep docs short, clear, current.
 - In `src`, make doc by crate. No module doc unless module become crate boundary.
+- When instructed to autonomously create issues or push changes to GitHub, refer to `.agents/autonomously-push-changes` for guidance. If no guidance exists, do not create issues or push changes. Never ever commit to develop branch or merge a pull request.
 
 ## Verification
 

--- a/docs/events/flow.md
+++ b/docs/events/flow.md
@@ -1,120 +1,205 @@
 # Event Flow
 
-All events originate from DynamoDB Stream changes on `table_1`. An EventBridge Pipe
-(`TableOneStreamToEventBusPipe`) filters relevant stream records and forwards them to the
-`DynamoDbEventBus`. EventBridge rules on that bus fan out to dedicated SQS queues, each
-consumed by a Lambda function.
+This document describes the target event flow for #1341. Current AWS DynamoDB Stream/EventBridge/SQS/Lambda rails stay only for AWS survivor workflows until cutover.
 
----
+See `docs/hetzner_postgres_sequin_migration.md` for the ADR.
 
-## Components
+## Target components
 
 | Component | Type | Purpose |
-|-----------|------|---------|
-| `table_1` | DynamoDB Table | Single event-store and read-model table |
-| `DynamoDbEventBus` | EventBridge Bus | Central routing bus for all DynamoDB stream events |
-| `TableOneStreamToEventBusPipe` | EventBridge Pipe | Filters DynamoDB stream records and publishes to the event bus |
-| `ProductMaterializeDynamoDbQ` | SQS + Lambda | Writes materialized product view to DynamoDB |
-| `ProductMaterializeOpenSearchQ` | SQS + Lambda | Indexes product updates in OpenSearch, including lifecycle |
-| `ProductDeleteProductQ` | SQS + Lambda | Deletes product from OpenSearch and removes watchlist/search-filter matches |
-| `ProductUpdateNotifyUserQ` | SQS + Lambda | Notifies watchlist users on price/state changes |
-| `SearchFilterPercolateProductQ` | SQS + Lambda | Matches products against saved search filters, notifies users |
-| `ProductPipelineTranslateQ` | SQS + Lambda | Translates product titles and descriptions (ML, GPU) |
-| `ProductPipelineEmbedTextQ` | SQS + Lambda | Creates vector embeddings via Gemini Embedding API |
-| `ShopOpenSearchIndexQ` | SQS + Lambda | Indexes shop records in OpenSearch |
-| `SearchFilterOpenSearchSyncQ` | SQS + Lambda | Syncs search filters to OpenSearch percolation queries |
-| `NotificationSendQ` | SQS + Lambda | Sends external notifications via SES |
-| `FxRateSyncLambda` | Lambda (scheduled) | Updates foreign exchange rates (every 12 h) |
+|---|---|---|
+| Postgres | Database | Business source of truth and transactional product/event writes. |
+| `product_events` | Postgres table | Product domain/enrichment/policy/lifecycle event log. |
+| Sequin | CDC | Delivers committed Postgres changes to worker ingestion. |
+| `worker_inbox` | Postgres table | Durable CDC/job inbox before in-memory queues. |
+| `aura-historia-worker` router | Rust process | Maps CDC/inbox rows to domain jobs. |
+| In-memory sub-worker queues | Worker buffers | Bounded execution buffers, not durability boundary. |
+| OpenSearch | Search projection | Rebuildable product/shop/search-filter projection. |
+| DynamoDB notifications | AWS DynamoDB | Notification TTL and insert-to-send behavior. |
+| `notification-send` | AWS Lambda | Sends external notifications through SES. |
+| FxRate Lambda | AWS Lambda | Updates FX rates in DynamoDB. |
+| Shopify Lambda | AWS Lambda | Handles Shopify events, writes Postgres directly. |
+| Stripe Lambda | AWS Lambda | Handles Stripe subscription events, writes Postgres directly. |
+| Step Functions | AWS workflow | Partner-shop-application workflow. |
+| CloudWatch log-retention Lambda | AWS Lambda | Keeps AWS log retention policy. |
 
----
-
-## Event Routing Diagram
+## Target routing diagram
 
 ```mermaid
 flowchart TD
-    API["Partner API\n(POST/PATCH/PUT/DELETE products)"]
-    DB[("DynamoDB\ntable_1")]
-    PIPE["EventBridge Pipe\nTableOneStreamToEventBusPipe"]
-    BUS["EventBridge Bus\nDynamoDbEventBus"]
+    API["aura-historia-api"]
+    SHOPIFY["Shopify Lambda"]
+    STRIPE["Stripe Lambda"]
+    SFN["Step Functions Lambda"]
+    PG[(Postgres)]
+    SEQ["Sequin CDC"]
+    INBOX[(worker_inbox)]
+    ROUTER["aura-historia-worker router"]
+    OS[(OpenSearch)]
+    DDBN[(DynamoDB notifications)]
+    SEND["notification-send Lambda"]
+    SES["SES"]
+    FX["FxRate Lambda"]
+    DDBFX[(DynamoDB FX rate)]
 
-    API -->|"write event record"| DB
-    DB -->|"DynamoDB Stream\n(NEW_IMAGE)"| PIPE
-    PIPE -->|"filtered INSERT/MODIFY/REMOVE"| BUS
+    API -->|"sync business transaction"| PG
+    SHOPIFY -->|"sync product/event transaction"| PG
+    STRIPE -->|"sync user update"| PG
+    SFN -->|"sync partner-app/shop/user update"| PG
 
-    %% Materialization
-    BUS -->|"DOMAIN_* / ENRICHMENT_* / POLICY_* / LIFECYCLE_* (INSERT)"| MatDDB["ProductMaterializeDynamoDbQ\n→ Lambda\n(write materialized view)"]
-    BUS -->|"DOMAIN_* / ENRICHMENT_* / POLICY_* / LIFECYCLE_* (INSERT)"| MatOS["ProductMaterializeOpenSearchQ\n→ Lambda\n(index in OpenSearch)"]
-    BUS -->|"LIFECYCLE_DELETED (INSERT)"| DeleteProduct["ProductDeleteProductQ\n→ Lambda\n(delete OpenSearch + cleanup user records)"]
+    PG -->|"committed row changes"| SEQ
+    SEQ -->|"deliver CDC"| INBOX
+    INBOX --> ROUTER
 
-    %% User notifications (only price & state changes)
-    BUS -->|"DOMAIN_PRICE_* / DOMAIN_STATE_* (INSERT)"| NotifyUser["ProductUpdateNotifyUserQ\n→ Lambda\n(notify watchlist users)"]
-    BUS -->|"DOMAIN_* / ENRICHMENT_* (INSERT)"| Percolate["SearchFilterPercolateProductQ\n→ Lambda\n(match saved search filters)"]
+    ROUTER -->|"product projection jobs"| OS
+    ROUTER -->|"shop projection jobs"| OS
+    ROUTER -->|"search-filter percolator docs"| OS
+    ROUTER -->|"match/watchlist/tier updates"| PG
+    ROUTER -->|"notification records"| DDBN
+    ROUTER -->|"enrichment events + product update"| PG
 
-    %% Enrichment pipeline (chained: embed-text fires first, translate fires second)
-    BUS -->|"DOMAIN_CREATED (INSERT)"| EmbedText["ProductPipelineEmbedTextQ\n→ Lambda\n(vector embedding via Gemini)"]
-    BUS -->|"ENRICHMENT_EMBEDDED (INSERT)"| Translate["ProductPipelineTranslateQ\n→ Lambda\n(translate title & description)"]
+    DDBN -->|"stream/event rule"| SEND
+    SEND --> SES
 
-    %% Enrichment pipeline writes back to DynamoDB
-    EmbedText -->|"write ENRICHMENT_EMBEDDED\n(transact-write with materialized record)"| DB
-    Translate -->|"write ENRICHMENT_TRANSLATED_TITLE\n(transact-write with materialized record)"| DB
-
-    %% Shop & search filter sync
-    BUS -->|"shop#details (INSERT/MODIFY)"| ShopOS["ShopOpenSearchIndexQ\n→ Lambda\n(index shop in OpenSearch)"]
-    BUS -->|"search_filter#* (INSERT/MODIFY/REMOVE)"| SFSync["SearchFilterOpenSearchSyncQ\n→ Lambda\n(sync percolation query)"]
-
-    %% External notification send
-    BUS -->|"user#notification#* + external=true (INSERT)"| SendNotif["NotificationSendQ\n→ Lambda\n(send email via SES)"]
-
-    %% Scheduled
-    SCHED2["Scheduler (every 12 h)"] --> FxRate["FxRateSyncLambda\n(update FX rates in DynamoDB)"]
+    FX --> DDBFX
 ```
 
----
+## Product write flow
 
-## Event-Chain State Diagram
-
-The diagram below shows which product event types cause new event types to be written back to
-`table_1` by the enrichment pipeline. `[*]` is the Mermaid notation for the initial state;
-events starting from `[*]` are written purely by the external API and have no preceding product
-event.
+Product writes are synchronous.
 
 ```mermaid
-stateDiagram-v2
-    [*] --> DOMAIN_CREATED
-    [*] --> DOMAIN_STATE_CHANGED
-    [*] --> DOMAIN_PRICE_CHANGED
-    [*] --> DOMAIN_ESTIMATE_PRICE_CHANGED
-    [*] --> DOMAIN_URL_CHANGED
-    [*] --> DOMAIN_IMAGES_CHANGED
-    [*] --> DOMAIN_AUCTION_TIME_CHANGED
-    [*] --> LIFECYCLE_DELETED
+sequenceDiagram
+    participant Caller
+    participant API as aura-historia-api or AWS intake Lambda
+    participant PG as Postgres
+    participant Sequin
+    participant Worker as aura-historia-worker
+    participant OS as OpenSearch
 
-    DOMAIN_CREATED --> ENRICHMENT_EMBEDDED
-    ENRICHMENT_EMBEDDED --> ENRICHMENT_TRANSLATED_TITLE
+    Caller->>API: product create/update/delete
+    API->>PG: begin transaction
+    API->>PG: lock/read product row
+    API->>PG: insert product_events
+    API->>PG: upsert/update products
+    API->>PG: commit
+    API-->>Caller: success/failure after commit
+    PG-->>Sequin: CDC after commit
+    Sequin->>Worker: deliver CDC
+    Worker->>PG: insert worker_inbox idempotently
+    Worker-->>Sequin: ack after durable write
+    Worker->>OS: project product/search side effects
 ```
 
----
+No intermediate product command SQS queue. No `202 accepted because queued` behavior for migrated writes.
 
-## Stream Filter Details
+## Durable worker inbox
 
-The EventBridge Pipe applies the following DynamoDB Filter Criteria before publishing to the bus:
+Sequin delivery is not processed directly in memory.
 
-| Filter | `pk` pattern | `sk` pattern | Operation |
-|--------|-------------|-------------|-----------|
-| Product events | `product#shop_id#*` | `product#event#*` | INSERT |
-| User details | `user#*` | `user#details` | MODIFY |
-| Shop details | `shop#shop_id#*` | `shop#details` | INSERT, MODIFY |
-| User notifications | `user#*` | `user#notification#origin_event_id#*` | INSERT |
-| Search filters | `user#*` | `search_filter#*` | INSERT, MODIFY, REMOVE |
+Minimum ingest steps:
 
----
+1. Receive CDC envelope.
+2. Validate source/table/operation.
+3. Derive stable `source_event_id`, `aggregate_type`, `aggregate_id`, and `ordering_key`.
+4. Insert into `worker_inbox` with unique `(source, source_event_id)`.
+5. Ack Sequin only after insert succeeds or duplicate is detected.
+6. Router leases pending inbox rows and pushes domain jobs to bounded in-memory queues.
+7. Sub-worker records processed idempotency key or failure.
 
-## Dead Letter Queues
+Crash rule:
 
-Every SQS queue has a corresponding DLQ. Retry limits:
+- Crash before inbox insert: Sequin redelivers.
+- Crash after inbox insert before ack: duplicate delivery becomes no-op insert.
+- Crash after enqueue: inbox row remains retryable unless processed marker exists.
 
-| Queue | Max Retries |
-|-------|-------------|
-| Materialization queues | 5 |
-| Notification queues | 5 |
-| Pipeline queues | 3 |
+## CDC routing draft
+
+| Source table | Operation | Route |
+|---|---|---|
+| `product_events` | INSERT | Product projector; percolator for domain/enrichment; watchlist notifications for price/state; enrichment pipeline for create/embed; delete cleanup for lifecycle delete. |
+| `products` | INSERT/MODIFY | No default downstream route. Product events are the projection trigger to avoid double-firing. Use products CDC only for explicit backfills or future non-event projections. |
+| `shops` / `shop_domains` | INSERT/MODIFY/DELETE | Shop OpenSearch projector. |
+| `search_filters` | INSERT/MODIFY/DELETE | Search-filter OpenSearch sync; user tier checks if state/feature-relevant. |
+| `search_filter_matches` | INSERT/MODIFY/DELETE | Usually no downstream route except observability/backfill. |
+| `users` | INSERT/MODIFY/DELETE | User tier enforcement for tier changes; no user OpenSearch projection. |
+| `product_watchlist` | INSERT/MODIFY/DELETE | Usually no downstream route except tier/backfill; product events drive notifications. |
+| `partner_shop_applications` | INSERT/MODIFY | No generic worker route unless notification/backfill requires it. |
+
+## Domain jobs
+
+Worker sub-jobs use domain payloads or compact IDs. They do not use DynamoDB stream records and should not depend on raw Sequin JSON outside the router.
+
+Examples:
+
+- `ProductEventJob`
+- `ProductDeletedJob`
+- `SearchFilterChangedJob`
+- `ShopChangedJob`
+- `UserTierChangedJob`
+- `PeriodicMatcherJob`
+
+## Target sub-workers
+
+| Sub-worker | Replaces | Input | Side effects |
+|---|---|---|---|
+| Product OpenSearch projector | `product-lambda-materialize-opensearch` | Product event job | OpenSearch product document create/update/delete. |
+| Product delete cleanup | `product-lambda-delete-product` | Lifecycle deleted job | OpenSearch delete, Postgres watchlist/match cleanup. |
+| Watchlist notification generator | `product-lambda-update-notify-user` | Price/state product event job | DynamoDB notification inserts. |
+| Search-filter percolator | `search-filter-lambda-percolate-product` | Domain/enrichment product event job | Postgres matches, DynamoDB notifications. |
+| Product embed | `product-pipeline-embed-text` | Domain created job | Postgres enrichment event + product update. |
+| Product translate | `product-pipeline-translate` | Enrichment embedded job | Postgres enrichment event + product update. |
+| Shop OpenSearch projector | `shop-lambda-opensearch-index` | Shop changed job | OpenSearch shop document write. |
+| Search-filter OpenSearch sync | `search-filter-lambda-opensearch-sync` | Search-filter changed job | OpenSearch percolator document write/delete. |
+| User tier enforcement | `user-lambda-tier-update` | User tier changed job | Postgres watchlist/search-filter state updates. |
+| Periodic matcher | ECS periodic matcher | Scheduled job | OpenSearch product search, Postgres matches, DynamoDB notifications. |
+
+## AWS survivor event flow
+
+These AWS event flows stay:
+
+| Source | Route | Target |
+|---|---|---|
+| DynamoDB notification insert | Stream/EventBridge/SQS | `notification-send` Lambda |
+| EventBridge schedule | cron | `fxrate-lambda` |
+| Shopify partner EventBridge/SQS | Shopify product events | `shopify-lambda`; this is external intake buffering before sync Postgres product/event writes, not the removed product command queue. |
+| Stripe partner EventBridge | subscription events | `stripe-lambda` |
+| Step Functions | partner app workflow | `partner-shop-application-lambda`; Lambda writes Postgres business rows directly. |
+| CloudWatch log group events | EventBridge | CloudWatch log-retention Lambda |
+
+## Idempotency
+
+Minimum unique keys:
+
+| Area | Key |
+|---|---|
+| Product event | `product_events.event_id` |
+| Worker inbox | `(source, source_event_id)`, where `source_event_id` is Sequin event ID or derived from `lsn + table + primary key + operation` |
+| Worker processed | `(worker_name, idempotency_key)` |
+| Search-filter match | `(user_search_filter_id, product_id)` plus user/filter/product lookup indexes |
+| Notification | user + origin event where domain allows |
+
+External sends remain at-least-once. Notification duplicate protection is at record creation, not SES delivery.
+
+## Retry and poison handling
+
+Each inbox row has:
+
+- `status`
+- `attempts`
+- `next_attempt_at`
+- `locked_by`
+- `locked_until`
+
+Sub-workers retry transient failures with backoff. Permanent failures move to `worker_failures` and keep enough payload to debug/replay.
+
+## Operations notes
+
+Postgres is business truth and Sequin depends on replication health. Production cutover needs backup/restore, WAL/PITR or accepted RPO, Sequin slot lag monitoring, worker inbox lag alerts, poison-count alerts, and Postgres connection monitoring.
+
+## Test guidance
+
+- Use Postgres integration tests for repository and inbox behavior.
+- Use fake CDC envelopes for router tests.
+- Use existing LocalStack OpenSearch for projection/percolator tests.
+- Keep DynamoDB and CDK/CloudFormation helpers for AWS survivor tests.

--- a/docs/events/flow.md
+++ b/docs/events/flow.md
@@ -12,7 +12,7 @@ See `docs/hetzner_postgres_sequin_migration.md` for the ADR.
 | `product_events` | Postgres table | Product domain/enrichment/policy/lifecycle event log. |
 | Sequin | CDC | Delivers committed Postgres changes to worker ingestion. |
 | `aura-historia-worker` router | Rust process | Maps CDC rows to domain jobs and fans them out to queues. |
-| In-memory sub-worker queues | Worker buffers | Bounded execution buffers. Own retry/DLQ behavior. |
+| In-memory sub-worker queues | Worker buffers | Bounded execution buffers. Not durable. |
 | OpenSearch | Search projection | Rebuildable product/shop/search-filter projection. |
 | DynamoDB notifications | AWS DynamoDB | Notification TTL and insert-to-send behavior. |
 | DynamoDB access tokens | AWS DynamoDB | Existing access-token storage and lookup. |
@@ -119,21 +119,22 @@ Crash rule:
 
 - Crash before Sequin ack: Sequin redelivers.
 - Crash after Sequin ack: queued in-memory jobs may be lost if the process dies before sub-workers finish.
-- Lost projection jobs are recoverable by rebuild/backfill.
-- User-visible side effects need durable idempotent first writes, for example DynamoDB notification rows keyed by user and origin event.
+- Crash after Sequin ack may lose queued in-memory jobs.
+- MVP accepts this risk.
+- No scheduled inconsistency checker or repair job is part of v1.
 
 ## CDC routing draft
 
 | Source table | Operation | Route |
 |---|---|---|
 | `product_events` | INSERT | Product projector; percolator for domain/enrichment; watchlist notifications for price/state; enrichment pipeline for create/embed; delete cleanup for lifecycle delete. |
-| `products` | INSERT/MODIFY | No default downstream route. Product events are the projection trigger to avoid double-firing. Use products CDC only for explicit backfills or future non-event projections. |
+| `products` | INSERT/MODIFY | No default downstream route. Product events are the projection trigger to avoid double-firing. Use products CDC only for future explicit non-event projections. |
 | `shops` | INSERT/MODIFY/DELETE | Shop OpenSearch projector. Domains are inline in `shops.shop_domains`. |
 | `search_filters` | INSERT/MODIFY/DELETE | Search-filter OpenSearch sync; user tier checks if state/feature-relevant. |
-| `search_filter_matches` | INSERT/MODIFY/DELETE | Usually no downstream route except observability/backfill. `origin_event_id` links to `product_events.event_id`. |
+| `search_filter_matches` | INSERT/MODIFY/DELETE | Usually no downstream route except observability. `origin_event_id` links to `product_events.event_id`. |
 | `users` | INSERT/MODIFY/DELETE | User tier enforcement for tier changes; no user OpenSearch projection. |
-| `product_watchlist` | INSERT/MODIFY/DELETE | Usually no downstream route except tier/backfill; product events drive notifications. |
-| `partner_shop_applications` | INSERT/MODIFY | No generic worker route unless notification/backfill requires it. |
+| `product_watchlist` | INSERT/MODIFY/DELETE | Usually no downstream route except tier enforcement; product events drive notifications. |
+| `partner_shop_applications` | INSERT/MODIFY | No generic worker route unless notification behavior requires it. |
 
 ## Domain jobs
 
@@ -186,10 +187,10 @@ Minimum unique keys:
 |---|---|
 | Product event | `product_events.event_id` |
 | Product materialized state | `products.event_id` |
-| Product worker job | `(worker_name, product_events.event_id)` |
-| Shop worker job | `(worker_name, shop_id, version, op)` |
-| Search-filter worker job | `(worker_name, user_search_filter_id, version, op)` |
-| User tier worker job | `(worker_name, user_id, version)` |
+| Product worker job | `product_events.event_id` |
+| Shop worker job | `(shop_id, version, op)` |
+| Search-filter worker job | `(user_search_filter_id, version, op)` |
+| User tier worker job | `(user_id, version)` |
 | Search-filter match | `(user_search_filter_id, product_id)` plus `origin_event_id` FK to `product_events.event_id` |
 | Notification | user + origin event where domain allows |
 
@@ -197,30 +198,24 @@ Sequin ID/LSN can be logged for debugging, but do not make it the normal idempot
 
 External sends remain at-least-once. Notification duplicate protection is at record creation, not SES delivery.
 
-## Retry and poison handling
+## Retry and failure handling
 
-Sub-workers own retry, backoff, and dead-letter behavior after enqueue.
+MVP has no worker-owned Postgres tables.
 
-Minimum queue/job state:
+- No durable inbox.
+- No processed-job table.
+- No dead-letter table.
+- No scheduled inconsistency checker or repair job.
 
-- domain job payload
-- `worker_name`
-- `idempotency_key`
-- attempts
-- next attempt time
-- last error
-
-Permanent failures are written to `worker_dead_letters` with enough payload to debug/replay.
+Sub-workers may retry transient failures while the process is alive. If the process dies after Sequin ack, queued jobs can be lost. This risk is accepted for MVP.
 
 ## Operations notes
 
-Postgres is business truth and Sequin depends on replication health. Production cutover needs backup/restore, WAL/PITR or accepted RPO, Sequin slot lag monitoring, worker queue lag alerts, dead-letter alerts, and Postgres connection monitoring.
-
-Because there is no durable inbox, projection rebuild and worker replay/backfill tools are part of the reliability model.
+Postgres is business truth and Sequin depends on replication health. Production cutover needs backup/restore, WAL/PITR or accepted RPO, Sequin replication lag monitoring, worker queue/error alerts, and Postgres connection monitoring.
 
 ## Test guidance
 
-- Use Postgres integration tests for repositories and durable processed/dead-letter markers.
+- Use Postgres integration tests for repositories.
 - Use fake CDC envelopes for router fanout tests.
 - Use existing LocalStack OpenSearch for projection/percolator tests.
 - Keep DynamoDB and CDK/CloudFormation helpers for AWS survivor tests.

--- a/docs/events/flow.md
+++ b/docs/events/flow.md
@@ -11,11 +11,11 @@ See `docs/hetzner_postgres_sequin_migration.md` for the ADR.
 | Postgres | Database | Business source of truth and transactional product/event writes. |
 | `product_events` | Postgres table | Product domain/enrichment/policy/lifecycle event log. |
 | Sequin | CDC | Delivers committed Postgres changes to worker ingestion. |
-| `worker_inbox` | Postgres table | Durable CDC/job inbox before in-memory queues. |
-| `aura-historia-worker` router | Rust process | Maps CDC/inbox rows to domain jobs. |
-| In-memory sub-worker queues | Worker buffers | Bounded execution buffers, not durability boundary. |
+| `aura-historia-worker` router | Rust process | Maps CDC rows to domain jobs and fans them out to queues. |
+| In-memory sub-worker queues | Worker buffers | Bounded execution buffers. Own retry/DLQ behavior. |
 | OpenSearch | Search projection | Rebuildable product/shop/search-filter projection. |
 | DynamoDB notifications | AWS DynamoDB | Notification TTL and insert-to-send behavior. |
+| DynamoDB access tokens | AWS DynamoDB | Existing access-token storage and lookup. |
 | `notification-send` | AWS Lambda | Sends external notifications through SES. |
 | FxRate Lambda | AWS Lambda | Updates FX rates in DynamoDB. |
 | Shopify Lambda | AWS Lambda | Handles Shopify events, writes Postgres directly. |
@@ -33,8 +33,10 @@ flowchart TD
     SFN["Step Functions Lambda"]
     PG[(Postgres)]
     SEQ["Sequin CDC"]
-    INBOX[(worker_inbox)]
     ROUTER["aura-historia-worker router"]
+    PQ["product queues"]
+    SQ["shop queues"]
+    UFQ["user/search-filter queues"]
     OS[(OpenSearch)]
     DDBN[(DynamoDB notifications)]
     SEND["notification-send Lambda"]
@@ -48,15 +50,19 @@ flowchart TD
     SFN -->|"sync partner-app/shop/user update"| PG
 
     PG -->|"committed row changes"| SEQ
-    SEQ -->|"deliver CDC"| INBOX
-    INBOX --> ROUTER
+    SEQ -->|"deliver CDC"| ROUTER
+    ROUTER -->|"ack after all fanout succeeds"| SEQ
 
-    ROUTER -->|"product projection jobs"| OS
-    ROUTER -->|"shop projection jobs"| OS
-    ROUTER -->|"search-filter percolator docs"| OS
-    ROUTER -->|"match/watchlist/tier updates"| PG
-    ROUTER -->|"notification records"| DDBN
-    ROUTER -->|"enrichment events + product update"| PG
+    ROUTER --> PQ
+    ROUTER --> SQ
+    ROUTER --> UFQ
+
+    PQ -->|"product projections"| OS
+    PQ -->|"match/watchlist/enrichment"| PG
+    PQ -->|"notification records"| DDBN
+    SQ -->|"shop projections"| OS
+    UFQ -->|"search-filter docs"| OS
+    UFQ -->|"tier/search-filter updates"| PG
 
     DDBN -->|"stream/event rule"| SEND
     SEND --> SES
@@ -75,43 +81,46 @@ sequenceDiagram
     participant PG as Postgres
     participant Sequin
     participant Worker as aura-historia-worker
+    participant Queue as In-memory queues
     participant OS as OpenSearch
 
     Caller->>API: product create/update/delete
     API->>PG: begin transaction
     API->>PG: lock/read product row
     API->>PG: insert product_events
-    API->>PG: upsert/update products
+    API->>PG: upsert/update products.event_id
     API->>PG: commit
     API-->>Caller: success/failure after commit
     PG-->>Sequin: CDC after commit
     Sequin->>Worker: deliver CDC
-    Worker->>PG: insert worker_inbox idempotently
-    Worker-->>Sequin: ack after durable write
-    Worker->>OS: project product/search side effects
+    Worker->>Worker: map to domain jobs
+    Worker->>Queue: enqueue to all relevant queues
+    Worker-->>Sequin: ack after fanout succeeds
+    Queue->>OS: project product/search side effects
 ```
 
 No intermediate product command SQS queue. No `202 accepted because queued` behavior for migrated writes.
 
-## Durable worker inbox
+## Sequin fanout contract
 
-Sequin delivery is not processed directly in memory.
+There is no durable `worker_inbox` table.
 
 Minimum ingest steps:
 
 1. Receive CDC envelope.
 2. Validate source/table/operation.
-3. Derive stable `source_event_id`, `aggregate_type`, `aggregate_id`, and `ordering_key`.
-4. Insert into `worker_inbox` with unique `(source, source_event_id)`.
-5. Ack Sequin only after insert succeeds or duplicate is detected.
-6. Router leases pending inbox rows and pushes domain jobs to bounded in-memory queues.
-7. Sub-worker records processed idempotency key or failure.
+3. Build domain change from row keys and before/after values.
+4. Derive domain-first `idempotency_key` and `ordering_key`.
+5. Map change to one or more domain jobs.
+6. Enqueue every job to every relevant bounded in-memory queue.
+7. Ack Sequin only after all enqueue operations succeed.
 
 Crash rule:
 
-- Crash before inbox insert: Sequin redelivers.
-- Crash after inbox insert before ack: duplicate delivery becomes no-op insert.
-- Crash after enqueue: inbox row remains retryable unless processed marker exists.
+- Crash before Sequin ack: Sequin redelivers.
+- Crash after Sequin ack: queued in-memory jobs may be lost if the process dies before sub-workers finish.
+- Lost projection jobs are recoverable by rebuild/backfill.
+- User-visible side effects need durable idempotent first writes, for example DynamoDB notification rows keyed by user and origin event.
 
 ## CDC routing draft
 
@@ -119,9 +128,9 @@ Crash rule:
 |---|---|---|
 | `product_events` | INSERT | Product projector; percolator for domain/enrichment; watchlist notifications for price/state; enrichment pipeline for create/embed; delete cleanup for lifecycle delete. |
 | `products` | INSERT/MODIFY | No default downstream route. Product events are the projection trigger to avoid double-firing. Use products CDC only for explicit backfills or future non-event projections. |
-| `shops` / `shop_domains` | INSERT/MODIFY/DELETE | Shop OpenSearch projector. |
+| `shops` | INSERT/MODIFY/DELETE | Shop OpenSearch projector. Domains are inline in `shops.shop_domains`. |
 | `search_filters` | INSERT/MODIFY/DELETE | Search-filter OpenSearch sync; user tier checks if state/feature-relevant. |
-| `search_filter_matches` | INSERT/MODIFY/DELETE | Usually no downstream route except observability/backfill. |
+| `search_filter_matches` | INSERT/MODIFY/DELETE | Usually no downstream route except observability/backfill. `origin_event_id` links to `product_events.event_id`. |
 | `users` | INSERT/MODIFY/DELETE | User tier enforcement for tier changes; no user OpenSearch projection. |
 | `product_watchlist` | INSERT/MODIFY/DELETE | Usually no downstream route except tier/backfill; product events drive notifications. |
 | `partner_shop_applications` | INSERT/MODIFY | No generic worker route unless notification/backfill requires it. |
@@ -147,10 +156,10 @@ Examples:
 | Product delete cleanup | `product-lambda-delete-product` | Lifecycle deleted job | OpenSearch delete, Postgres watchlist/match cleanup. |
 | Watchlist notification generator | `product-lambda-update-notify-user` | Price/state product event job | DynamoDB notification inserts. |
 | Search-filter percolator | `search-filter-lambda-percolate-product` | Domain/enrichment product event job | Postgres matches, DynamoDB notifications. |
-| Product embed | `product-pipeline-embed-text` | Domain created job | Postgres enrichment event + product update. |
+| Product embed | `product-pipeline-embed-text` | Domain created job | Postgres enrichment event + product update. Embedding stored in Postgres only. |
 | Product translate | `product-pipeline-translate` | Enrichment embedded job | Postgres enrichment event + product update. |
 | Shop OpenSearch projector | `shop-lambda-opensearch-index` | Shop changed job | OpenSearch shop document write. |
-| Search-filter OpenSearch sync | `search-filter-lambda-opensearch-sync` | Search-filter changed job | OpenSearch percolator document write/delete. |
+| Search-filter OpenSearch sync | `search-filter-lambda-opensearch-sync` | Search-filter changed job | OpenSearch percolator document write/delete. Search-filter embedding stored in Postgres only. |
 | User tier enforcement | `user-lambda-tier-update` | User tier changed job | Postgres watchlist/search-filter state updates. |
 | Periodic matcher | ECS periodic matcher | Scheduled job | OpenSearch product search, Postgres matches, DynamoDB notifications. |
 
@@ -169,37 +178,49 @@ These AWS event flows stay:
 
 ## Idempotency
 
+Prefer domain IDs or domain versions over Sequin IDs.
+
 Minimum unique keys:
 
 | Area | Key |
 |---|---|
 | Product event | `product_events.event_id` |
-| Worker inbox | `(source, source_event_id)`, where `source_event_id` is Sequin event ID or derived from `lsn + table + primary key + operation` |
-| Worker processed | `(worker_name, idempotency_key)` |
-| Search-filter match | `(user_search_filter_id, product_id)` plus user/filter/product lookup indexes |
+| Product materialized state | `products.event_id` |
+| Product worker job | `(worker_name, product_events.event_id)` |
+| Shop worker job | `(worker_name, shop_id, version, op)` |
+| Search-filter worker job | `(worker_name, user_search_filter_id, version, op)` |
+| User tier worker job | `(worker_name, user_id, version)` |
+| Search-filter match | `(user_search_filter_id, product_id)` plus `origin_event_id` FK to `product_events.event_id` |
 | Notification | user + origin event where domain allows |
+
+Sequin ID/LSN can be logged for debugging, but do not make it the normal idempotency key when a domain key exists.
 
 External sends remain at-least-once. Notification duplicate protection is at record creation, not SES delivery.
 
 ## Retry and poison handling
 
-Each inbox row has:
+Sub-workers own retry, backoff, and dead-letter behavior after enqueue.
 
-- `status`
-- `attempts`
-- `next_attempt_at`
-- `locked_by`
-- `locked_until`
+Minimum queue/job state:
 
-Sub-workers retry transient failures with backoff. Permanent failures move to `worker_failures` and keep enough payload to debug/replay.
+- domain job payload
+- `worker_name`
+- `idempotency_key`
+- attempts
+- next attempt time
+- last error
+
+Permanent failures are written to `worker_dead_letters` with enough payload to debug/replay.
 
 ## Operations notes
 
-Postgres is business truth and Sequin depends on replication health. Production cutover needs backup/restore, WAL/PITR or accepted RPO, Sequin slot lag monitoring, worker inbox lag alerts, poison-count alerts, and Postgres connection monitoring.
+Postgres is business truth and Sequin depends on replication health. Production cutover needs backup/restore, WAL/PITR or accepted RPO, Sequin slot lag monitoring, worker queue lag alerts, dead-letter alerts, and Postgres connection monitoring.
+
+Because there is no durable inbox, projection rebuild and worker replay/backfill tools are part of the reliability model.
 
 ## Test guidance
 
-- Use Postgres integration tests for repository and inbox behavior.
-- Use fake CDC envelopes for router tests.
+- Use Postgres integration tests for repositories and durable processed/dead-letter markers.
+- Use fake CDC envelopes for router fanout tests.
 - Use existing LocalStack OpenSearch for projection/percolator tests.
 - Keep DynamoDB and CDK/CloudFormation helpers for AWS survivor tests.

--- a/docs/hetzner_postgres_sequin_migration.md
+++ b/docs/hetzner_postgres_sequin_migration.md
@@ -1,0 +1,208 @@
+# ADR: Hetzner/Postgres/Sequin migration
+
+Status: draft for review  
+Parent: #1341  
+Covers: #1368, #1369, #1374
+
+## Decision
+
+Move most backend business runtime from AWS serverless/DynamoDB to a Hetzner-friendly service layout:
+
+- `aura-historia-api` — REST API process.
+- `aura-historia-worker` — async worker process.
+- Postgres — business source of truth.
+- Sequin — Postgres CDC delivery into the worker.
+- OpenSearch — rebuildable search/percolator projection.
+- CloudFront — public edge in front of the Hetzner API origin.
+
+Design must not assume one machine. The default deployment may run all services on one host, but API, worker, Postgres, Sequin, and OpenSearch must be configurable as separate hosts.
+
+Design must keep a later move back to AWS practical. API and worker should be normal container-friendly Rust processes. Business logic should depend on repositories and domain jobs, not Hetzner-specific infrastructure.
+
+## Non-goals
+
+- No API Gateway adapter while migrating API routes.
+- No product command SQS buffer for migrated writes.
+- No DynamoDB auth/access-token cache.
+- No user OpenSearch index in target design.
+- No crawler migration. Crawler is separate and out of scope.
+- No exactly-once external side effects. Use idempotency and retry.
+
+## AWS stays
+
+| AWS part | Target role |
+|---|---|
+| Cognito | Identity provider only. API verifies JWTs directly. |
+| DynamoDB notifications | Notification TTL and insert-to-send workflow. |
+| `notification-send` Lambda | Sends external notifications through SES/S3 template flow. |
+| Step Functions | Partner-shop-application workflow engine. Its Lambda writes business rows to Postgres directly. |
+| Shopify Lambda | Shopify event intake stays in AWS, then writes product rows/events to Postgres directly. Its AWS SQS queue is external intake buffering, not a product command buffer. |
+| Stripe Lambda | Stripe subscription event intake stays in AWS, writes user rows to Postgres directly. |
+| OAuth clients and codes | Stay in DynamoDB. Access tokens move to Postgres only. |
+| FxRate Lambda | Scheduled FX-rate update stays in AWS/DynamoDB. |
+| CloudWatch log-retention Lambda | Stays for AWS logs. |
+| CloudFront/WAF | Public edge for Hetzner API origin. |
+
+## AWS Lambda to Postgres access
+
+AWS survivor Lambdas that need business data connect to Postgres directly.
+
+Minimum rules:
+
+- Use TLS to Postgres.
+- Keep credentials in AWS SSM/Secrets Manager or equivalent secret source.
+- Keep connection pools very small in Lambda runtimes.
+- Put a connection pooler such as PgBouncer in front of Postgres if direct Lambda concurrency can exceed safe Postgres connections.
+- Restrict network path by allowlist, VPN, tunnel, private overlay, or another reviewed control.
+- Monitor failed connects, connection count, pool wait, and auth failures.
+
+## Business source of truth
+
+Postgres owns:
+
+- users
+- access tokens
+- shops
+- partner-shop-applications
+- products
+- product-events
+- product-watchlist
+- search-filters
+- search-filter matches
+- worker inbox/checkpoints/failures/idempotency
+
+DynamoDB owns only:
+
+- notifications
+- OAuth clients
+- OAuth authorization codes
+- OAuth third-party exchange codes
+- FX rate
+
+OpenSearch owns only rebuildable projections:
+
+- products
+- shops
+- search-filter percolator documents
+
+## Product writes
+
+Product writes are synchronous.
+
+API/webhook/Shopify write flow:
+
+1. Authorize request.
+2. Load needed Postgres rows and FX rate.
+3. Decide domain event(s).
+4. In one Postgres transaction:
+   - insert `product_events`
+   - update `products` materialized row
+5. Commit.
+6. Return success/failure to caller.
+7. Sequin delivers committed changes to `aura-historia-worker`.
+
+No intermediate product command queue. No `202 accepted because queued` semantics for migrated product writes.
+
+## CDC and worker durability
+
+In-memory worker queues are not durable.
+
+Sequin delivery must first land in a durable Postgres worker inbox before ack. Worker sub-queues are only execution buffers.
+
+Target flow:
+
+1. Postgres commit creates/updates/deletes business rows.
+2. Sequin sends CDC event to `aura-historia-worker`.
+3. Worker validates and stores `worker_inbox` row idempotently.
+4. Worker acknowledges Sequin only after durable inbox write.
+5. Router leases inbox rows and maps them to domain jobs.
+6. Sub-workers consume bounded in-memory queues.
+7. Each sub-worker records processed idempotency key or failure.
+8. Retry/backoff or poison row handles failures.
+
+## Domain job rule
+
+Sub-workers consume domain jobs, not raw infrastructure payloads.
+
+Examples:
+
+- `ProductEventJob { event_id, product_id, event_type }`
+- `ShopChangedJob { shop_id }`
+- `SearchFilterChangedJob { user_id, user_search_filter_id, op }`
+- `UserTierChangedJob { user_id }`
+- `PeriodicMatcherJob`
+
+Raw Sequin envelopes stay at the edge.
+
+## Worker sub-workers
+
+| Sub-worker | Source | Side effects |
+|---|---|---|
+| Product OpenSearch projector | `product_events` | OpenSearch product upsert/update/delete. |
+| Product delete cleanup | `LIFECYCLE_DELETED` event | OpenSearch delete, Postgres watchlist/match cleanup. |
+| Watchlist notification generator | price/state product events | DynamoDB notification insert. |
+| Search-filter percolator | domain/enrichment product events | Postgres matches, DynamoDB notifications. |
+| Product embed | `DOMAIN_CREATED` event | Postgres enrichment event + product row update. |
+| Product translate | `ENRICHMENT_EMBEDDED` event | Postgres enrichment event + product row update. |
+| Shop OpenSearch projector | shop changes | OpenSearch shop upsert. |
+| Search-filter OpenSearch sync | search-filter changes | OpenSearch percolator document upsert/delete. |
+| User tier enforcement | user tier changes | Postgres watchlist/search-filter state updates. |
+| Periodic matcher | internal schedule | OpenSearch product search, Postgres matches, DynamoDB notifications. |
+
+## Idempotency and ordering
+
+Minimum rules:
+
+- `product_events.event_id` is unique.
+- `worker_inbox.source + source_event_id` is unique. Derive `source_event_id` from Sequin event ID when present, otherwise from `lsn + table + primary key + operation`.
+- `worker_processed_events.worker + idempotency_key` is unique.
+- Search-filter matches have a unique key preventing duplicate user/filter/product matches.
+- Notifications are idempotent by user and origin event where domain allows it.
+- Product projectors use event timestamp/version/LSN to avoid stale overwrite where practical.
+
+Ordering:
+
+- Product writes serialize per product row in Postgres.
+- Worker should route product event jobs with a per-product ordering key.
+- Cross-product ordering is not required.
+
+## Testing strategy
+
+- Prefer fast Postgres integration tests over full LocalStack CloudFormation tests.
+- Use existing LocalStack OpenSearch support for projection/percolator tests and mapping bootstrap.
+- Keep DynamoDB test helpers for notification/OAuth/FX survivor tests.
+- Keep CDK/CloudFormation acceptance deployment ability for infra/survivor wiring.
+- Move most REST acceptance coverage to `aura-historia-api` + Postgres + targeted LocalStack services.
+
+## Operations minimum
+
+Postgres becomes business truth. Before production cutover, add:
+
+- tested backup and restore path
+- point-in-time recovery or explicit accepted RPO
+- WAL retention policy
+- Sequin replication slot lag monitoring
+- database connection monitoring
+- schema migration rollout/rollback runbook
+- worker inbox lag and poison-count alerts
+
+## Deployment target
+
+Default single-host process set:
+
+- Postgres
+- Sequin
+- OpenSearch
+- `aura-historia-api`
+- `aura-historia-worker`
+
+All endpoints are env-driven. Postgres and OpenSearch may move to dedicated hosts without code changes.
+
+CloudFront fronts the API. The Hetzner origin must use TLS and origin protection, such as a secret origin header checked by `aura-historia-api`.
+
+## Open questions
+
+- Exact migration/backfill need for pre-production data.
+- Exact Sequin delivery mode and auth for worker endpoint.
+- Exact deployment tool: Docker Compose, systemd, Terraform, Ansible, or mix.
+- Metrics sink for Hetzner-hosted logs/metrics.

--- a/docs/hetzner_postgres_sequin_migration.md
+++ b/docs/hetzner_postgres_sequin_migration.md
@@ -23,10 +23,9 @@ Design must keep a later move back to AWS practical. API and worker should be no
 
 - No API Gateway adapter while migrating API routes.
 - No product command SQS buffer for migrated writes.
-- No DynamoDB auth/access-token cache.
-- No user OpenSearch index in target design.
+- No users OpenSearch index in target design.
 - No crawler migration. Crawler is separate and out of scope.
-- No exactly-once external side effects. Use idempotency and retry.
+- No exactly-once external side effects. Use idempotency, retry, and repair/backfill.
 
 ## AWS stays
 
@@ -34,11 +33,12 @@ Design must keep a later move back to AWS practical. API and worker should be no
 |---|---|
 | Cognito | Identity provider only. API verifies JWTs directly. |
 | DynamoDB notifications | Notification TTL and insert-to-send workflow. |
+| DynamoDB access tokens | Keep existing access-token storage and lookup. |
+| DynamoDB OAuth clients and codes | Keep OAuth clients, authorization codes, and third-party exchange codes. |
 | `notification-send` Lambda | Sends external notifications through SES/S3 template flow. |
 | Step Functions | Partner-shop-application workflow engine. Its Lambda writes business rows to Postgres directly. |
 | Shopify Lambda | Shopify event intake stays in AWS, then writes product rows/events to Postgres directly. Its AWS SQS queue is external intake buffering, not a product command buffer. |
 | Stripe Lambda | Stripe subscription event intake stays in AWS, writes user rows to Postgres directly. |
-| OAuth clients and codes | Stay in DynamoDB. Access tokens move to Postgres only. |
 | FxRate Lambda | Scheduled FX-rate update stays in AWS/DynamoDB. |
 | CloudWatch log-retention Lambda | Stays for AWS logs. |
 | CloudFront/WAF | Public edge for Hetzner API origin. |
@@ -61,7 +61,6 @@ Minimum rules:
 Postgres owns:
 
 - users
-- access tokens
 - shops
 - partner-shop-applications
 - products
@@ -69,11 +68,12 @@ Postgres owns:
 - product-watchlist
 - search-filters
 - search-filter matches
-- worker inbox/checkpoints/failures/idempotency
+- worker processed-job markers, dead letters, and schedules
 
-DynamoDB owns only:
+DynamoDB owns:
 
 - notifications
+- access tokens
 - OAuth clients
 - OAuth authorization codes
 - OAuth third-party exchange codes
@@ -96,29 +96,38 @@ API/webhook/Shopify write flow:
 3. Decide domain event(s).
 4. In one Postgres transaction:
    - insert `product_events`
-   - update `products` materialized row
+   - update `products` materialized row, including `products.event_id`
 5. Commit.
 6. Return success/failure to caller.
 7. Sequin delivers committed changes to `aura-historia-worker`.
 
 No intermediate product command queue. No `202 accepted because queued` semantics for migrated product writes.
 
-## CDC and worker durability
+## CDC and worker delivery
 
-In-memory worker queues are not durable.
+There is no durable `worker_inbox` table.
 
-Sequin delivery must first land in a durable Postgres worker inbox before ack. Worker sub-queues are only execution buffers.
+A CDC change is complete from the Sequin side only after `aura-historia-worker` fans it out to every relevant bounded in-memory sub-worker queue.
 
 Target flow:
 
 1. Postgres commit creates/updates/deletes business rows.
 2. Sequin sends CDC event to `aura-historia-worker`.
-3. Worker validates and stores `worker_inbox` row idempotently.
-4. Worker acknowledges Sequin only after durable inbox write.
-5. Router leases inbox rows and maps them to domain jobs.
-6. Sub-workers consume bounded in-memory queues.
-7. Each sub-worker records processed idempotency key or failure.
-8. Retry/backoff or poison row handles failures.
+3. Worker validates source/table/operation and maps the change to domain jobs.
+4. Worker derives domain-first idempotency and ordering keys.
+5. Worker pushes every derived domain job to all relevant bounded in-memory queues.
+6. Worker acknowledges Sequin after all enqueue operations succeed.
+7. Sub-workers own retry/backoff and dead-letter behavior.
+8. Sub-workers record processed-job markers or dead letters where durable visibility is needed.
+
+Crash rule:
+
+- Crash before Sequin ack: Sequin redelivers.
+- Crash after Sequin ack but before sub-worker completion: in-memory jobs may be lost.
+- Lost projection jobs are repaired by rebuild/backfill because OpenSearch is rebuildable.
+- Jobs with user-visible side effects must make their first external effect idempotent and durable, such as inserting a DynamoDB notification keyed by domain origin event.
+
+This accepts process-memory queues as the first fanout boundary for lower cost and simpler local tests. It requires repair/backfill tooling for any side effect that cannot be safely recomputed.
 
 ## Domain job rule
 
@@ -127,12 +136,12 @@ Sub-workers consume domain jobs, not raw infrastructure payloads.
 Examples:
 
 - `ProductEventJob { event_id, product_id, event_type }`
-- `ShopChangedJob { shop_id }`
-- `SearchFilterChangedJob { user_id, user_search_filter_id, op }`
-- `UserTierChangedJob { user_id }`
+- `ShopChangedJob { shop_id, version }`
+- `SearchFilterChangedJob { user_id, user_search_filter_id, version, op }`
+- `UserTierChangedJob { user_id, version }`
 - `PeriodicMatcherJob`
 
-Raw Sequin envelopes stay at the edge.
+Raw Sequin envelopes stay at the router edge.
 
 ## Worker sub-workers
 
@@ -151,14 +160,21 @@ Raw Sequin envelopes stay at the edge.
 
 ## Idempotency and ordering
 
+Prefer domain IDs or domain versions over technology-specific CDC IDs.
+
 Minimum rules:
 
-- `product_events.event_id` is unique.
-- `worker_inbox.source + source_event_id` is unique. Derive `source_event_id` from Sequin event ID when present, otherwise from `lsn + table + primary key + operation`.
-- `worker_processed_events.worker + idempotency_key` is unique.
+- Product events use `product_events.event_id`.
+- Product materialized writes use `products.event_id`.
+- Product workers use `event_id` as the idempotency key and `product_id` as the ordering key.
+- Shop workers use `(shop_id, version, op)` where version changes on each shop mutation.
+- Search-filter workers use `(user_search_filter_id, version, op)`.
+- User tier workers use `(user_id, version)`.
 - Search-filter matches have a unique key preventing duplicate user/filter/product matches.
-- Notifications are idempotent by user and origin event where domain allows it.
-- Product projectors use event timestamp/version/LSN to avoid stale overwrite where practical.
+- Notifications are idempotent by user and domain origin event where domain allows it.
+- `worker_processed_jobs.worker_name + idempotency_key` is unique where durable processed markers are useful.
+
+Use Sequin IDs, LSNs, or raw envelope IDs only as observability fields or last-resort fallback. Do not couple core idempotency to Sequin where a stable domain key exists.
 
 Ordering:
 
@@ -170,7 +186,7 @@ Ordering:
 
 - Prefer fast Postgres integration tests over full LocalStack CloudFormation tests.
 - Use existing LocalStack OpenSearch support for projection/percolator tests and mapping bootstrap.
-- Keep DynamoDB test helpers for notification/OAuth/FX survivor tests.
+- Keep DynamoDB test helpers for notification/OAuth/access-token/FX survivor tests.
 - Keep CDK/CloudFormation acceptance deployment ability for infra/survivor wiring.
 - Move most REST acceptance coverage to `aura-historia-api` + Postgres + targeted LocalStack services.
 
@@ -184,7 +200,8 @@ Postgres becomes business truth. Before production cutover, add:
 - Sequin replication slot lag monitoring
 - database connection monitoring
 - schema migration rollout/rollback runbook
-- worker inbox lag and poison-count alerts
+- worker queue lag, retry, and dead-letter alerts
+- rebuild/backfill runbooks for OpenSearch and worker-derived side effects
 
 ## Deployment target
 

--- a/docs/hetzner_postgres_sequin_migration.md
+++ b/docs/hetzner_postgres_sequin_migration.md
@@ -25,7 +25,7 @@ Design must keep a later move back to AWS practical. API and worker should be no
 - No product command SQS buffer for migrated writes.
 - No users OpenSearch index in target design.
 - No crawler migration. Crawler is separate and out of scope.
-- No exactly-once external side effects. Use idempotency, retry, and repair/backfill.
+- No exactly-once external side effects. MVP accepts in-memory worker loss risk after Sequin ack.
 
 ## AWS stays
 
@@ -68,7 +68,7 @@ Postgres owns:
 - product-watchlist
 - search-filters
 - search-filter matches
-- worker processed-job markers, dead letters, and schedules
+
 
 DynamoDB owns:
 
@@ -117,17 +117,17 @@ Target flow:
 4. Worker derives domain-first idempotency and ordering keys.
 5. Worker pushes every derived domain job to all relevant bounded in-memory queues.
 6. Worker acknowledges Sequin after all enqueue operations succeed.
-7. Sub-workers own retry/backoff and dead-letter behavior.
-8. Sub-workers record processed-job markers or dead letters where durable visibility is needed.
+7. Sub-workers run jobs from memory. MVP has no worker-owned Postgres tables for retry, processed markers, dead letters, or schedules.
 
 Crash rule:
 
 - Crash before Sequin ack: Sequin redelivers.
 - Crash after Sequin ack but before sub-worker completion: in-memory jobs may be lost.
-- Lost projection jobs are repaired by rebuild/backfill because OpenSearch is rebuildable.
-- Jobs with user-visible side effects must make their first external effect idempotent and durable, such as inserting a DynamoDB notification keyed by domain origin event.
+- Crash after Sequin ack may lose queued in-memory jobs.
+- MVP accepts this risk. No scheduled inconsistency checker or repair job is part of the initial migration.
+- Side effects should still be idempotent where easy, but this is not the v1 durability boundary.
 
-This accepts process-memory queues as the first fanout boundary for lower cost and simpler local tests. It requires repair/backfill tooling for any side effect that cannot be safely recomputed.
+This accepts process-memory queues as the first fanout boundary for lower cost and simpler local tests.
 
 ## Domain job rule
 
@@ -172,7 +172,7 @@ Minimum rules:
 - User tier workers use `(user_id, version)`.
 - Search-filter matches have a unique key preventing duplicate user/filter/product matches.
 - Notifications are idempotent by user and domain origin event where domain allows it.
-- `worker_processed_jobs.worker_name + idempotency_key` is unique where durable processed markers are useful.
+
 
 Use Sequin IDs, LSNs, or raw envelope IDs only as observability fields or last-resort fallback. Do not couple core idempotency to Sequin where a stable domain key exists.
 
@@ -200,8 +200,7 @@ Postgres becomes business truth. Before production cutover, add:
 - Sequin replication slot lag monitoring
 - database connection monitoring
 - schema migration rollout/rollback runbook
-- worker queue lag, retry, and dead-letter alerts
-- rebuild/backfill runbooks for OpenSearch and worker-derived side effects
+- worker queue lag and error alerts
 
 ## Deployment target
 
@@ -219,7 +218,7 @@ CloudFront fronts the API. The Hetzner origin must use TLS and origin protection
 
 ## Open questions
 
-- Exact migration/backfill need for pre-production data.
+- Exact data carry-over need for pre-production data.
 - Exact Sequin delivery mode and auth for worker endpoint.
 - Exact deployment tool: Docker Compose, systemd, Terraform, Ansible, or mix.
 - Metrics sink for Hetzner-hosted logs/metrics.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,7 +9,6 @@ See `docs/hetzner_postgres_sequin_migration.md` for the architecture ADR.
 Postgres owns business truth for:
 
 - users
-- access tokens
 - shops
 - partner-shop-applications
 - products
@@ -17,11 +16,12 @@ Postgres owns business truth for:
 - product-watchlist
 - search-filters
 - search-filter matches
-- worker inbox/checkpoints/failures/idempotency
+- worker processed-job markers, dead letters, and schedules
 
 DynamoDB keeps:
 
 - notifications with TTL and insert-to-send behavior
+- access tokens, as today
 - OAuth clients
 - OAuth authorization codes
 - OAuth third-party exchange codes
@@ -29,9 +29,7 @@ DynamoDB keeps:
 
 OpenSearch keeps search projections only. It is rebuildable.
 
-There is no target DynamoDB access-token cache and no target users OpenSearch index.
-
-Crawler storage is out of scope for this migration.
+There is no target users OpenSearch index. Crawler storage is out of scope for this migration.
 
 ## Postgres runtime contract
 
@@ -86,6 +84,73 @@ src/<crate>/src/postgres/<entity>_row.rs
 src/<crate>/migrations/...
 ```
 
+## Schema map
+
+```mermaid
+erDiagram
+    USERS ||--o{ USER_PARTNER_SHOPS : owns
+    SHOPS ||--o{ USER_PARTNER_SHOPS : grants
+    USERS ||--o{ PARTNER_SHOP_APPLICATIONS : applies
+    SHOPS ||--o{ PARTNER_SHOP_APPLICATIONS : existing_shop
+    SHOPS ||--o{ PRODUCTS : shop
+    SHOPS ||--o{ PRODUCTS : seller
+    PRODUCTS ||--o{ PRODUCT_EVENTS : emits
+    USERS ||--o{ PRODUCT_WATCHLIST : watches
+    PRODUCTS ||--o{ PRODUCT_WATCHLIST : watched
+    USERS ||--o{ SEARCH_FILTERS : owns
+    SEARCH_FILTERS ||--o{ SEARCH_FILTER_MATCHES : matches
+    PRODUCTS ||--o{ SEARCH_FILTER_MATCHES : matched_product
+    PRODUCT_EVENTS ||--o{ SEARCH_FILTER_MATCHES : origin_event
+
+    USERS {
+        uuid user_id PK
+        text email UK
+        text tier
+        text role
+        text stripe_customer_id UK
+        bigint version
+    }
+    SHOPS {
+        uuid shop_id PK
+        text shop_slug_id UK
+        text name
+        text_array shop_domains
+        bigint version
+    }
+    PRODUCTS {
+        uuid product_id PK
+        uuid event_id FK
+        uuid shop_id FK
+        uuid seller_id FK
+        text shops_product_id
+        jsonb product_images
+        real_array embedding
+    }
+    PRODUCT_EVENTS {
+        uuid event_id PK
+        uuid product_id FK
+        text event_type
+        jsonb payload
+        timestamptz event_time
+    }
+    SEARCH_FILTERS {
+        uuid user_search_filter_id PK
+        uuid user_id FK
+        jsonb search
+        real_array embedding
+        bigint version
+    }
+    SEARCH_FILTER_MATCHES {
+        uuid user_search_filter_id PK,FK
+        uuid product_id PK,FK
+        uuid origin_event_id FK
+    }
+    WORKER_PROCESSED_JOBS {
+        text worker_name PK
+        text idempotency_key PK
+    }
+```
+
 ## Schema draft
 
 ### Users
@@ -106,6 +171,7 @@ src/<crate>/migrations/...
 - flattened address columns
 - `geo_address_lat double precision null`
 - `geo_address_lon double precision null`
+- `version bigint not null default 1`
 - audit columns: `created_by`, `updated_by`, `created`, `updated`
 
 `user_partner_shops`
@@ -114,25 +180,7 @@ src/<crate>/migrations/...
 - `shop_id uuid references shops(shop_id) on delete cascade`
 - primary key `(user_id, shop_id)`
 
-`access_tokens`
-
-- `access_token_id uuid primary key`
-- `user_id uuid references users(user_id) on delete cascade`
-- `name text not null`
-- `token_prefix text not null`
-- `token_short text not null`
-- `token_hash text not null`
-- `origin text not null`
-- `oauth_client_id uuid null`
-- `expires timestamptz null`
-- audit columns
-- unique `(token_prefix, token_short)`
-
-`access_token_scopes`
-
-- `access_token_id uuid references access_tokens(access_token_id) on delete cascade`
-- `scope text not null`
-- primary key `(access_token_id, scope)`
+Access tokens stay in DynamoDB as today. Do not add `access_tokens` or `access_token_scopes` to Postgres.
 
 ### Shops
 
@@ -143,6 +191,7 @@ src/<crate>/migrations/...
 - `name text not null`
 - `shop_type text not null`
 - `partner_status text not null`
+- `shop_domains text[] not null default '{}'`
 - `shopify_domain text null unique`
 - `shopify_currency text null`
 - `shopify_language text null`
@@ -158,18 +207,17 @@ src/<crate>/migrations/...
 - `phone text null`
 - `email text null`
 - `affiliate_configuration jsonb null`
+- `version bigint not null default 1`
 - audit columns
 
-`shop_domains`
+Indexes:
 
-- `shop_id uuid references shops(shop_id) on delete cascade`
-- `domain text not null unique`
-- primary key `(shop_id, domain)`
+- GIN on `shop_domains` for domain lookup.
+- `(partner_status, updated desc)` if needed by admin lists.
 
-`shop_raw_name_aliases`
+`shop_domains` is intentionally inline because domains are aggregate-owned values. Canonicalize domains in the repository. If strict global uniqueness per domain becomes mandatory at the database layer, re-normalize domains into a child table.
 
-- `raw_shop_name text primary key`
-- `shop_id uuid not null references shops(shop_id) on delete cascade`
+No `shop_raw_name_aliases` table. It is unused and should not be migrated.
 
 ### Partner shop applications
 
@@ -183,6 +231,7 @@ src/<crate>/migrations/...
 - `existing_shop_id uuid null references shops(shop_id)`
 - new-shop payload columns: name, type, domains, url, image, address, phone, email
 - `task_token text null`
+- `version bigint not null default 1`
 - audit columns
 
 Indexes:
@@ -198,7 +247,7 @@ Indexes:
 - `product_slug_id text not null`
 - `shop_slug_id text not null`
 - `seller_slug_id text not null`
-- `last_event_id uuid not null`
+- `event_id uuid not null references product_events(event_id)`
 - `shop_id uuid not null references shops(shop_id)`
 - `seller_id uuid not null references shops(shop_id)`
 - `shops_product_id text not null`
@@ -212,7 +261,8 @@ Indexes:
 - `lifecycle text not null`
 - `url text not null`
 - `view_url text not null`
-- `embedding real[] null` or `vector` if pgvector is adopted later
+- `product_images jsonb not null default '[]'`
+- `embedding real[] null`
 - `auction_start timestamptz null`
 - `auction_end timestamptz null`
 - audit columns
@@ -224,13 +274,9 @@ Constraints/indexes:
 - index `(seller_id)`
 - index `(lifecycle, updated desc)`
 
-`product_images`
+`product_images` is intentionally inline because images are ordered aggregate-owned values and are not queried independently. Store objects with at least `position`, `url`, and optional `prohibited_content`.
 
-- `product_id uuid references products(product_id) on delete cascade`
-- `position int not null`
-- `url text not null`
-- `prohibited_content text null`
-- primary key `(product_id, position)`
+`embedding` is stored only. Do not add ANN search or pgvector behavior until a later task explicitly needs it.
 
 `product_events`
 
@@ -282,16 +328,19 @@ Indexes:
 - `state text not null`
 - search criteria columns where stable and `search jsonb not null` for flexible criteria
 - `enhanced_search_description text null`
-- `embedding real[] null` or `vector` if pgvector is adopted later
+- `embedding real[] null`
 - `language text not null`
 - `currency text not null`
 - `last_hybrid_search_matched timestamptz not null default '1970-01-01T00:00:00Z'`
+- `version bigint not null default 1`
 - audit columns
 
 Indexes:
 
 - `(user_id, created desc)`
 - `(state, updated desc)`
+
+`embedding` is stored only. Do not add ANN search or pgvector behavior until a later task explicitly needs it.
 
 `search_filter_matches`
 
@@ -300,7 +349,7 @@ Indexes:
 - `product_id uuid not null references products(product_id) on delete cascade`
 - `shop_id uuid not null`
 - `shops_product_id text not null`
-- `origin_event_id uuid not null`
+- `origin_event_id uuid not null references product_events(event_id)`
 - `user_search_filter_name text null`
 - `enhanced_match_reason text null`
 - `feedback boolean null`
@@ -312,49 +361,39 @@ Indexes:
 - `(user_id, created desc)`
 - `(user_id, user_search_filter_id, created desc)`
 - `(product_id)`
+- `(origin_event_id)`
 - unique `(user_id, user_search_filter_id, shop_id, shops_product_id)`
 
 ### Worker
 
-`worker_inbox`
+No `worker_inbox` table. Sequin delivery is acknowledged after the router has delivered all derived domain jobs to the relevant bounded in-memory queues.
 
-- `inbox_id uuid primary key`
-- `source text not null`
-- `source_event_id text not null` — Sequin event ID, or derived from `source_lsn + table_name + primary key + operation`
-- `source_lsn pg_lsn null`
-- `table_name text not null`
-- `operation text not null`
-- `aggregate_type text not null`
-- `aggregate_id text not null`
-- `ordering_key text not null`
-- `payload jsonb not null`
-- `status text not null`
-- `attempts int not null default 0`
-- `next_attempt_at timestamptz not null default now()`
-- `locked_by text null`
-- `locked_until timestamptz null`
-- `created timestamptz not null default now()`
-- `updated timestamptz not null default now()`
-- unique `(source, source_event_id)`
-- index `(status, next_attempt_at)`
-- index `(ordering_key, created)`
-
-`worker_processed_events`
+`worker_processed_jobs`
 
 - `worker_name text not null`
 - `idempotency_key text not null`
 - `processed_at timestamptz not null default now()`
 - primary key `(worker_name, idempotency_key)`
 
-`worker_failures`
+Use domain-first idempotency keys:
 
-- `failure_id uuid primary key`
-- `inbox_id uuid not null references worker_inbox(inbox_id)`
+- product jobs: `product_events.event_id`
+- shop jobs: `(shop_id, version, op)`
+- search-filter jobs: `(user_search_filter_id, version, op)`
+- user tier jobs: `(user_id, version)`
+- match jobs: `(user_search_filter_id, product_id, origin_event_id)`
+
+`worker_dead_letters`
+
+- `dead_letter_id uuid primary key`
 - `worker_name text not null`
+- `idempotency_key text not null`
+- `job_type text not null`
 - `error_kind text not null`
 - `error_message text not null`
 - `payload jsonb not null`
 - `created timestamptz not null default now()`
+- unique `(worker_name, idempotency_key)` where appropriate
 
 Optional:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -16,7 +16,7 @@ Postgres owns business truth for:
 - product-watchlist
 - search-filters
 - search-filter matches
-- worker processed-job markers, dead letters, and schedules
+
 
 DynamoDB keeps:
 
@@ -145,10 +145,7 @@ erDiagram
         uuid product_id PK,FK
         uuid origin_event_id FK
     }
-    WORKER_PROCESSED_JOBS {
-        text worker_name PK
-        text idempotency_key PK
-    }
+
 ```
 
 ## Schema draft
@@ -294,7 +291,7 @@ Indexes:
 
 - `(product_id, event_time asc)`
 - `(shop_id, shops_product_id, event_time asc)`
-- `(event_type, event_time asc)` for worker routing/backfill
+- `(event_type, event_time asc)` for worker routing
 
 Product writes insert `product_events` and update `products` in one transaction.
 
@@ -366,16 +363,16 @@ Indexes:
 
 ### Worker
 
-No `worker_inbox` table. Sequin delivery is acknowledged after the router has delivered all derived domain jobs to the relevant bounded in-memory queues.
+No worker-owned Postgres tables in MVP.
 
-`worker_processed_jobs`
+- No `worker_inbox`.
+- No `worker_processed_jobs`.
+- No `worker_dead_letters`.
+- No `worker_schedules`.
 
-- `worker_name text not null`
-- `idempotency_key text not null`
-- `processed_at timestamptz not null default now()`
-- primary key `(worker_name, idempotency_key)`
+Sequin delivery is acknowledged after the router has delivered all derived domain jobs to the relevant bounded in-memory queues. If the worker process or host dies after ack, those in-memory jobs can be lost. MVP accepts this risk and does not add a scheduled inconsistency checker or repair job.
 
-Use domain-first idempotency keys:
+Use domain-first idempotency keys inside jobs and target writes where easy:
 
 - product jobs: `product_events.event_id`
 - shop jobs: `(shop_id, version, op)`
@@ -383,28 +380,6 @@ Use domain-first idempotency keys:
 - user tier jobs: `(user_id, version)`
 - match jobs: `(user_search_filter_id, product_id, origin_event_id)`
 
-`worker_dead_letters`
-
-- `dead_letter_id uuid primary key`
-- `worker_name text not null`
-- `idempotency_key text not null`
-- `job_type text not null`
-- `error_kind text not null`
-- `error_message text not null`
-- `payload jsonb not null`
-- `created timestamptz not null default now()`
-- unique `(worker_name, idempotency_key)` where appropriate
-
-Optional:
-
-`worker_schedules`
-
-- `job_name text primary key`
-- `next_run_at timestamptz not null`
-- `locked_by text null`
-- `locked_until timestamptz null`
-
-Used for periodic matcher multi-instance safety.
 
 ## Test pattern
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,13 +1,15 @@
 # Storage ownership
 
-This repo is migrating business truth from DynamoDB to Postgres. Public API behavior must stay stable during the migration.
+This repo is migrating most business truth from DynamoDB to Postgres as part of #1341.
+
+See `docs/hetzner_postgres_sequin_migration.md` for the architecture ADR.
 
 ## Target owners
 
 Postgres owns business truth for:
 
 - users
-- access-token canonical metadata
+- access tokens
 - shops
 - partner-shop-applications
 - products
@@ -15,21 +17,27 @@ Postgres owns business truth for:
 - product-watchlist
 - search-filters
 - search-filter matches
+- worker inbox/checkpoints/failures/idempotency
 
 DynamoDB keeps:
 
 - notifications with TTL and insert-to-send behavior
-- OAuth short-lived authorization/exchange codes
+- OAuth clients
+- OAuth authorization codes
+- OAuth third-party exchange codes
 - FX rate
-- required auth/token lookup cache projected from Postgres
 
 OpenSearch keeps search projections only. It is rebuildable.
+
+There is no target DynamoDB access-token cache and no target users OpenSearch index.
+
+Crawler storage is out of scope for this migration.
 
 ## Postgres runtime contract
 
 Postgres is self-hosted. No RDS Proxy.
 
-Infra provides these env vars to explicitly opted-in Lambdas and service tasks:
+Runtimes receive explicit env vars:
 
 - `POSTGRES_HOST`
 - `POSTGRES_PORT`
@@ -38,19 +46,17 @@ Infra provides these env vars to explicitly opted-in Lambdas and service tasks:
 - `POSTGRES_PASSWORD`
 - `POSTGRES_MAX_CONNECTIONS`
 
-Real stages resolve host/user/db/password from SSM. Ephemeral uses local Docker defaults for integration tests.
-
-Lambda crates should build pools with `common::postgres::PostgresPoolConfig` and keep pools small. Default max is `2`.
+Do not assume Postgres is on the same machine as API or worker.
 
 ## Migration location
 
-Each business crate owns its SQLx migrations under:
+Each business crate owns SQLx migrations under:
 
 ```text
 src/<crate>/migrations/
 ```
 
-Use SQLx migration filenames with sortable prefixes:
+Use sortable filenames:
 
 ```text
 YYYYMMDDHHMMSS_short_description.sql
@@ -62,13 +68,14 @@ Migration files must be idempotent where integration tests re-run them (`CREATE 
 
 For a Postgres-backed entity:
 
-- Keep the domain trait clean in the crate service/domain seam.
+- Keep domain traits clean in the crate service/domain seam.
 - Put SQL implementation under `src/<crate>/src/postgres/`.
 - Name SQL DTOs `Row` when they represent DB rows.
 - Handlers depend on service traits, not SQLx.
 - Services may depend on repository traits, not concrete pool construction.
 - Use typed errors with `thiserror`; map `sqlx::Error` at the repository edge.
-- No global outbox table. Outbox tables are owner/action/entity-specific.
+- Use one repository/DAO per external source.
+- Keep DynamoDB adapters only for DynamoDB-owned data.
 
 Suggested shape:
 
@@ -78,6 +85,287 @@ src/<crate>/src/postgres/repository.rs
 src/<crate>/src/postgres/<entity>_row.rs
 src/<crate>/migrations/...
 ```
+
+## Schema draft
+
+### Users
+
+`users`
+
+- `user_id uuid primary key`
+- `email text not null unique`
+- `first_name text null`
+- `last_name text null`
+- `language text null`
+- `currency text null`
+- `measurement_unit text null`
+- `prohibited_content_consent boolean not null default false`
+- `tier text not null`
+- `role text not null`
+- `stripe_customer_id text null unique`
+- flattened address columns
+- `geo_address_lat double precision null`
+- `geo_address_lon double precision null`
+- audit columns: `created_by`, `updated_by`, `created`, `updated`
+
+`user_partner_shops`
+
+- `user_id uuid references users(user_id) on delete cascade`
+- `shop_id uuid references shops(shop_id) on delete cascade`
+- primary key `(user_id, shop_id)`
+
+`access_tokens`
+
+- `access_token_id uuid primary key`
+- `user_id uuid references users(user_id) on delete cascade`
+- `name text not null`
+- `token_prefix text not null`
+- `token_short text not null`
+- `token_hash text not null`
+- `origin text not null`
+- `oauth_client_id uuid null`
+- `expires timestamptz null`
+- audit columns
+- unique `(token_prefix, token_short)`
+
+`access_token_scopes`
+
+- `access_token_id uuid references access_tokens(access_token_id) on delete cascade`
+- `scope text not null`
+- primary key `(access_token_id, scope)`
+
+### Shops
+
+`shops`
+
+- `shop_id uuid primary key`
+- `shop_slug_id text not null unique`
+- `name text not null`
+- `shop_type text not null`
+- `partner_status text not null`
+- `shopify_domain text null unique`
+- `shopify_currency text null`
+- `shopify_language text null`
+- `woocommerce_webhook_secret text null`
+- `woocommerce_currency text null`
+- `woocommerce_language text null`
+- `url text null`
+- `view_url text null`
+- `image text null`
+- flattened address columns
+- `geo_address_lat double precision null`
+- `geo_address_lon double precision null`
+- `phone text null`
+- `email text null`
+- `affiliate_configuration jsonb null`
+- audit columns
+
+`shop_domains`
+
+- `shop_id uuid references shops(shop_id) on delete cascade`
+- `domain text not null unique`
+- primary key `(shop_id, domain)`
+
+`shop_raw_name_aliases`
+
+- `raw_shop_name text primary key`
+- `shop_id uuid not null references shops(shop_id) on delete cascade`
+
+### Partner shop applications
+
+`partner_shop_applications`
+
+- `partner_shop_application_id uuid primary key`
+- `applicant_user_id uuid not null references users(user_id)`
+- `business_state text not null`
+- `execution_state text not null`
+- `payload_type text not null`
+- `existing_shop_id uuid null references shops(shop_id)`
+- new-shop payload columns: name, type, domains, url, image, address, phone, email
+- `task_token text null`
+- audit columns
+
+Indexes:
+
+- `(applicant_user_id, created desc)`
+- `(business_state, created desc)`
+
+### Products
+
+`products`
+
+- `product_id uuid primary key`
+- `product_slug_id text not null`
+- `shop_slug_id text not null`
+- `seller_slug_id text not null`
+- `last_event_id uuid not null`
+- `shop_id uuid not null references shops(shop_id)`
+- `seller_id uuid not null references shops(shop_id)`
+- `shops_product_id text not null`
+- denormalized shop/seller name/type fields needed by search and notifications
+- flattened address columns
+- native title/description fields with language
+- localized title fields: `title_de`, `title_en`, `title_fr`, `title_es`, `title_it`
+- native and converted price fields
+- native and converted estimate min/max price fields
+- `state text not null`
+- `lifecycle text not null`
+- `url text not null`
+- `view_url text not null`
+- `embedding real[] null` or `vector` if pgvector is adopted later
+- `auction_start timestamptz null`
+- `auction_end timestamptz null`
+- audit columns
+
+Constraints/indexes:
+
+- unique `(shop_id, shops_product_id)`
+- unique `(shop_slug_id, product_slug_id)`
+- index `(seller_id)`
+- index `(lifecycle, updated desc)`
+
+`product_images`
+
+- `product_id uuid references products(product_id) on delete cascade`
+- `position int not null`
+- `url text not null`
+- `prohibited_content text null`
+- primary key `(product_id, position)`
+
+`product_events`
+
+- `event_id uuid primary key`
+- `product_id uuid not null references products(product_id)`
+- `shop_id uuid not null`
+- `shops_product_id text not null`
+- `event_type text not null`
+- `event_group text not null` (`DOMAIN`, `ENRICHMENT`, `POLICY`, `LIFECYCLE`)
+- `payload jsonb not null`
+- `event_time timestamptz not null`
+- audit/write-source columns where useful
+
+Indexes:
+
+- `(product_id, event_time asc)`
+- `(shop_id, shops_product_id, event_time asc)`
+- `(event_type, event_time asc)` for worker routing/backfill
+
+Product writes insert `product_events` and update `products` in one transaction.
+
+### Product watchlist
+
+`product_watchlist`
+
+- `user_id uuid references users(user_id) on delete cascade`
+- `product_id uuid references products(product_id) on delete cascade`
+- `shop_id uuid not null`
+- `shops_product_id text not null`
+- `notifications boolean not null default true`
+- `state text not null`
+- audit columns
+- primary key `(user_id, product_id)`
+
+Indexes:
+
+- `(user_id, created desc)`
+- `(product_id)`
+- unique `(user_id, shop_id, shops_product_id)`
+
+### Search filters
+
+`search_filters`
+
+- `user_search_filter_id uuid primary key`
+- `user_id uuid references users(user_id) on delete cascade`
+- `name text not null`
+- `notifications boolean not null default true`
+- `state text not null`
+- search criteria columns where stable and `search jsonb not null` for flexible criteria
+- `enhanced_search_description text null`
+- `embedding real[] null` or `vector` if pgvector is adopted later
+- `language text not null`
+- `currency text not null`
+- `last_hybrid_search_matched timestamptz not null default '1970-01-01T00:00:00Z'`
+- audit columns
+
+Indexes:
+
+- `(user_id, created desc)`
+- `(state, updated desc)`
+
+`search_filter_matches`
+
+- `user_id uuid not null references users(user_id) on delete cascade`
+- `user_search_filter_id uuid not null references search_filters(user_search_filter_id) on delete cascade`
+- `product_id uuid not null references products(product_id) on delete cascade`
+- `shop_id uuid not null`
+- `shops_product_id text not null`
+- `origin_event_id uuid not null`
+- `user_search_filter_name text null`
+- `enhanced_match_reason text null`
+- `feedback boolean null`
+- audit columns
+- primary key `(user_search_filter_id, product_id)`
+
+Indexes:
+
+- `(user_id, created desc)`
+- `(user_id, user_search_filter_id, created desc)`
+- `(product_id)`
+- unique `(user_id, user_search_filter_id, shop_id, shops_product_id)`
+
+### Worker
+
+`worker_inbox`
+
+- `inbox_id uuid primary key`
+- `source text not null`
+- `source_event_id text not null` — Sequin event ID, or derived from `source_lsn + table_name + primary key + operation`
+- `source_lsn pg_lsn null`
+- `table_name text not null`
+- `operation text not null`
+- `aggregate_type text not null`
+- `aggregate_id text not null`
+- `ordering_key text not null`
+- `payload jsonb not null`
+- `status text not null`
+- `attempts int not null default 0`
+- `next_attempt_at timestamptz not null default now()`
+- `locked_by text null`
+- `locked_until timestamptz null`
+- `created timestamptz not null default now()`
+- `updated timestamptz not null default now()`
+- unique `(source, source_event_id)`
+- index `(status, next_attempt_at)`
+- index `(ordering_key, created)`
+
+`worker_processed_events`
+
+- `worker_name text not null`
+- `idempotency_key text not null`
+- `processed_at timestamptz not null default now()`
+- primary key `(worker_name, idempotency_key)`
+
+`worker_failures`
+
+- `failure_id uuid primary key`
+- `inbox_id uuid not null references worker_inbox(inbox_id)`
+- `worker_name text not null`
+- `error_kind text not null`
+- `error_message text not null`
+- `payload jsonb not null`
+- `created timestamptz not null default now()`
+
+Optional:
+
+`worker_schedules`
+
+- `job_name text primary key`
+- `next_run_at timestamptz not null`
+- `locked_by text null`
+- `locked_until timestamptz null`
+
+Used for periodic matcher multi-instance safety.
 
 ## Test pattern
 
@@ -105,4 +393,10 @@ const POSTGRES: Postgres = Postgres::with_setup_script(
 );
 ```
 
-The test harness starts one Postgres Docker container per test binary, reruns migrations before each test, and truncates public tables after each test.
+Keep existing LocalStack OpenSearch, DynamoDB, SQS, and CloudFormation helpers for AWS survivor and infra tests.
+
+## Operations notes
+
+Postgres is business truth. Production cutover needs backup/restore, WAL/PITR or accepted RPO, Sequin slot lag monitoring, connection monitoring, and migration rollback runbooks.
+
+AWS survivor Lambdas connect to Postgres directly. Use TLS, tightly scoped credentials, small pools, and a reviewed network control such as allowlist, VPN, tunnel, or private overlay. Add PgBouncer or equivalent if Lambda concurrency can exceed safe Postgres connections.


### PR DESCRIPTION
Parent epic: #1341

Refs #1368
Refs #1369
Refs #1374

## Summary

- Add draft ADR for the target Hetzner/Postgres/Sequin architecture.
- Update storage ownership and draft Postgres schema.
- Update event flow for Sequin CDC, durable worker inbox, and `aura-historia-worker` routing.

## Review focus

- AWS survivor boundaries.
- Product sync-write semantics.
- Worker inbox durability/idempotency.
- Postgres schema direction.
- Lambda-to-Postgres operational risk.

## Validation

- `git diff --check`

Do not merge until reviewed.