### PR TITLE
task(#1371): add API and worker runtime skeletons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,10 +219,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aura-historia-api"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "rstest",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "aura-historia-parent"
 version = "0.1.0"
 dependencies = [
  "acceptance-tests",
+ "aura-historia-api",
+ "aura-historia-worker",
  "aws-tests",
  "cloudwatch-log-retention-lambda",
  "cognito",
@@ -264,6 +277,17 @@ dependencies = [
  "user-api",
  "user-lambda",
  "webhook-api",
+]
+
+[[package]]
+name = "aura-historia-worker"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "rstest",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+aura-historia-api = { workspace = true }
+aura-historia-worker = { workspace = true }
 aws-tests = { workspace = true }
 acceptance-tests = { workspace = true }
 cognito = { workspace = true }
@@ -50,6 +52,8 @@ partner-shop-application-lambda = { workspace = true }
 [workspace]
 members = [
     "src/acceptance-tests",
+    "src/aura-historia-api",
+    "src/aura-historia-worker",
     "src/aws-tests",
     "src/cognito",
     "src/cloudwatch-log-retention-lambda",
@@ -95,6 +99,8 @@ members = [
 ]
 
 [workspace.dependencies]
+aura-historia-api = { path = "src/aura-historia-api" }
+aura-historia-worker = { path = "src/aura-historia-worker" }
 async-stream = "0.3.6"
 base64 = "0.23.0"
 async-trait = "0.1.89"

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Core Design
 
-- Workspace split by job: domain libs hold rules, `*-api` crates speak HTTP, `*-lambda` crates speak event/runtime, test crates prove behavior.
+- Workspace split by job: domain libs hold rules, `*-api`/`aura-historia-api` crates speak HTTP, `aura-historia-worker` handles async CDC/queues, survivor `*-lambda` crates speak AWS event/runtime, test crates prove behavior.
 - Keep reusable logic in domain or service modules. Handler `main.rs`, route files, and Lambda bootstrap stay thin.
 - Shared OpenSearch assets under `src/opensearch/` stay governed here unless they grow own durable boundary.
 - Crate submodule-design
@@ -87,6 +87,8 @@
 ## Child DOX Index
 
 - `src/acceptance-tests/AGENTS.md` — `acceptance-tests` crate.
+- `src/aura-historia-api/AGENTS.md` — `aura-historia-api` crate.
+- `src/aura-historia-worker/AGENTS.md` — `aura-historia-worker` crate.
 - `src/aws-tests/AGENTS.md` — `aws-tests` crate.
 - `src/ci-determinator/AGENTS.md` — `ci-determinator` crate.
 - `src/cloudwatch-log-retention-lambda/AGENTS.md` — `cloudwatch-log-retention-lambda` crate.

--- a/src/aura-historia-api/AGENTS.md
+++ b/src/aura-historia-api/AGENTS.md
@@ -1,0 +1,38 @@
+# DOX
+
+## Purpose
+
+- Own bare-metal REST API runtime skeleton for #1341.
+
+## Core Design
+
+- `main.rs` bootstraps logging, config, and graceful shutdown.
+- `lib.rs` owns runtime config, minimal router, health/readiness endpoints, and server loop.
+- No API Gateway adapter.
+- Domain routes will be mounted here in later tasks.
+
+## Ownership
+
+- This doc rule `src/aura-historia-api/**`.
+- Parent doc: `src/AGENTS.md`.
+
+## Local Contracts
+
+- Read repo root, `src/AGENTS.md`, then here before edit.
+- Update this doc when env vars, route shape, dependencies, or runtime behavior changes.
+- Public API route behavior must update `docs/swagger.yaml` and `docs/CHANGELOG.md` when routes become real.
+
+## Work Guidance
+
+- Keep runtime glue thin.
+- Put business behavior in domain crates and services.
+- Use runtime-neutral request/auth context; no API Gateway context.
+
+## Verification
+
+- `cargo check -p aura-historia-api`
+- `cargo test -p aura-historia-api --all-features`
+
+## Child DOX Index
+
+- None.

--- a/src/aura-historia-api/Cargo.toml
+++ b/src/aura-historia-api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "aura-historia-api"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+common = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/src/aura-historia-api/src/lib.rs
+++ b/src/aura-historia-api/src/lib.rs
@@ -1,0 +1,247 @@
+use std::future::Future;
+use std::net::{AddrParseError, SocketAddr};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, error, info};
+
+pub const API_BIND_ADDR_ENV: &str = "AURA_HISTORIA_API_BIND_ADDR";
+const DEFAULT_API_BIND_ADDR: &str = "0.0.0.0:8080";
+const REQUEST_BUFFER_BYTES: usize = 8192;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiConfig {
+    bind_addr: SocketAddr,
+}
+
+impl ApiConfig {
+    pub fn from_env() -> Result<Self, ApiConfigError> {
+        Self::from_getter(|name| std::env::var(name).ok())
+    }
+
+    pub fn from_getter<F>(mut get: F) -> Result<Self, ApiConfigError>
+    where
+        F: FnMut(&'static str) -> Option<String>,
+    {
+        let raw_bind_addr =
+            get(API_BIND_ADDR_ENV).unwrap_or_else(|| DEFAULT_API_BIND_ADDR.to_owned());
+        let bind_addr =
+            raw_bind_addr
+                .parse()
+                .map_err(|source| ApiConfigError::InvalidBindAddr {
+                    value: raw_bind_addr,
+                    source,
+                })?;
+
+        Ok(Self { bind_addr })
+    }
+
+    pub const fn bind_addr(&self) -> SocketAddr {
+        self.bind_addr
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ApiConfigError {
+    #[error("invalid {env_name}: {value}", env_name = API_BIND_ADDR_ENV)]
+    InvalidBindAddr {
+        value: String,
+        source: AddrParseError,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthResponse {
+    pub status_code: u16,
+    pub body: &'static str,
+}
+
+pub fn route(method: &str, path: &str) -> HealthResponse {
+    match (method, path) {
+        ("GET", "/health") => HealthResponse {
+            status_code: 200,
+            body: "ok\n",
+        },
+        ("GET", "/ready") => HealthResponse {
+            status_code: 200,
+            body: "ready\n",
+        },
+        _ => HealthResponse {
+            status_code: 404,
+            body: "not found\n",
+        },
+    }
+}
+
+pub async fn run_until_shutdown<S>(config: ApiConfig, shutdown: S) -> Result<(), ApiRunError>
+where
+    S: Future<Output = ()>,
+{
+    let listener = TcpListener::bind(config.bind_addr())
+        .await
+        .map_err(ApiRunError::Bind)?;
+    serve(listener, shutdown).await
+}
+
+pub async fn serve<S>(listener: TcpListener, shutdown: S) -> Result<(), ApiRunError>
+where
+    S: Future<Output = ()>,
+{
+    let local_addr = listener.local_addr().map_err(ApiRunError::LocalAddr)?;
+    info!(bind_addr = %local_addr, "aura-historia-api listening");
+    tokio::pin!(shutdown);
+
+    loop {
+        tokio::select! {
+            accept_result = listener.accept() => {
+                let (stream, peer_addr) = accept_result.map_err(ApiRunError::Accept)?;
+                debug!(%peer_addr, "accepted API connection");
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(stream).await {
+                        error!(%error, "API connection failed");
+                    }
+                });
+            }
+            () = &mut shutdown => {
+                info!("aura-historia-api shutdown requested");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn handle_connection(mut stream: TcpStream) -> Result<(), std::io::Error> {
+    let mut buffer = [0_u8; REQUEST_BUFFER_BYTES];
+    let bytes_read = stream.read(&mut buffer).await?;
+    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let (method, path) = parse_request_line(&request).unwrap_or(("", ""));
+    let response = route(method, path);
+    write_response(&mut stream, response).await
+}
+
+fn parse_request_line(request: &str) -> Option<(&str, &str)> {
+    let line = request.lines().next()?;
+    let mut parts = line.split_whitespace();
+    let method = parts.next()?;
+    let path = parts.next()?;
+    Some((method, path))
+}
+
+async fn write_response(
+    stream: &mut TcpStream,
+    response: HealthResponse,
+) -> Result<(), std::io::Error> {
+    let status = match response.status_code {
+        200 => "200 OK",
+        404 => "404 Not Found",
+        _ => "500 Internal Server Error",
+    };
+    let bytes = response.body.as_bytes();
+    stream
+        .write_all(
+            format!(
+                "HTTP/1.1 {status}\r\ncontent-length: {}\r\ncontent-type: text/plain\r\nconnection: close\r\n\r\n{}",
+                bytes.len(),
+                response.body
+            )
+            .as_bytes(),
+        )
+        .await
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ApiRunError {
+    #[error("failed to bind API listener")]
+    Bind(#[source] std::io::Error),
+    #[error("failed to read API listener local address")]
+    LocalAddr(#[source] std::io::Error),
+    #[error("failed to accept API connection")]
+    Accept(#[source] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use rstest::rstest;
+    use tokio::sync::oneshot;
+
+    fn env(values: &[(&'static str, &str)]) -> HashMap<&'static str, String> {
+        values
+            .iter()
+            .map(|(key, value)| (*key, (*value).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn should_use_default_bind_addr_when_env_missing() -> Result<(), Box<dyn std::error::Error>> {
+        let values = env(&[]);
+
+        let config = ApiConfig::from_getter(|name| values.get(name).cloned())?;
+
+        assert_eq!("0.0.0.0:8080".parse::<SocketAddr>()?, config.bind_addr());
+        Ok(())
+    }
+
+    #[test]
+    fn should_read_bind_addr_from_env() -> Result<(), Box<dyn std::error::Error>> {
+        let values = env(&[(API_BIND_ADDR_ENV, "127.0.0.1:9000")]);
+
+        let config = ApiConfig::from_getter(|name| values.get(name).cloned())?;
+
+        assert_eq!("127.0.0.1:9000".parse::<SocketAddr>()?, config.bind_addr());
+        Ok(())
+    }
+
+    #[test]
+    fn should_fail_when_bind_addr_is_invalid() {
+        let values = env(&[(API_BIND_ADDR_ENV, "not-an-addr")]);
+
+        let config = ApiConfig::from_getter(|name| values.get(name).cloned());
+
+        assert!(matches!(
+            config,
+            Err(ApiConfigError::InvalidBindAddr { .. })
+        ));
+    }
+
+    #[rstest]
+    #[case("GET", "/health", 200, "ok\n")]
+    #[case("GET", "/ready", 200, "ready\n")]
+    #[case("POST", "/health", 404, "not found\n")]
+    fn should_route_health_endpoints(
+        #[case] method: &str,
+        #[case] path: &str,
+        #[case] status_code: u16,
+        #[case] body: &'static str,
+    ) {
+        let response = route(method, path);
+
+        assert_eq!(status_code, response.status_code);
+        assert_eq!(body, response.body);
+    }
+
+    #[tokio::test]
+    async fn should_serve_health_endpoint_until_shutdown() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(serve(listener, async move {
+            let _ = shutdown_rx.await;
+        }));
+
+        let mut stream = TcpStream::connect(addr).await?;
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nhost: localhost\r\n\r\n")
+            .await?;
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await?;
+        let _send_result = shutdown_tx.send(());
+        server.await??;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.ends_with("ok\n"));
+        Ok(())
+    }
+}

--- a/src/aura-historia-api/src/main.rs
+++ b/src/aura-historia-api/src/main.rs
@@ -1,0 +1,23 @@
+use aura_historia_api::{ApiConfig, ApiConfigError, ApiRunError, run_until_shutdown};
+
+#[tokio::main]
+async fn main() -> Result<(), MainError> {
+    common::logging::init_logging();
+    let config = ApiConfig::from_env()?;
+    run_until_shutdown(config, shutdown_signal()).await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        tracing::error!(%error, "failed to listen for shutdown signal");
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum MainError {
+    #[error(transparent)]
+    Config(#[from] ApiConfigError),
+    #[error(transparent)]
+    Run(#[from] ApiRunError),
+}

--- a/src/aura-historia-worker/AGENTS.md
+++ b/src/aura-historia-worker/AGENTS.md
@@ -1,0 +1,38 @@
+# DOX
+
+## Purpose
+
+- Own bare-metal async worker runtime skeleton for #1341.
+
+## Core Design
+
+- `main.rs` bootstraps logging, config, health server, and graceful shutdown.
+- `lib.rs` owns runtime config, health/readiness endpoints, server loop, and bounded in-memory queue primitives.
+- Worker consumes future Sequin CDC, routes domain changes to in-memory queues, then sub-workers handle retries/DLQ in process.
+- No worker persistence tables in MVP. Crash after CDC fan-out may lose queued jobs.
+
+## Ownership
+
+- This doc rule `src/aura-historia-worker/**`.
+- Parent doc: `src/AGENTS.md`.
+
+## Local Contracts
+
+- Read repo root, `src/AGENTS.md`, then here before edit.
+- Update this doc when env vars, queue behavior, dependencies, or runtime behavior changes.
+- Event-flow changes must update `docs/events/flow.md`.
+
+## Work Guidance
+
+- Keep runtime glue thin.
+- Queue payloads should be domain types or domain IDs, not Sequin/AWS envelopes.
+- Keep queue abstraction replaceable by SQS/Lambda/ECS later.
+
+## Verification
+
+- `cargo check -p aura-historia-worker`
+- `cargo test -p aura-historia-worker --all-features`
+
+## Child DOX Index
+
+- None.

--- a/src/aura-historia-worker/Cargo.toml
+++ b/src/aura-historia-worker/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "aura-historia-worker"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+common = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/src/aura-historia-worker/src/lib.rs
+++ b/src/aura-historia-worker/src/lib.rs
@@ -1,0 +1,363 @@
+use std::future::Future;
+use std::net::{AddrParseError, SocketAddr};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info};
+
+pub const WORKER_HEALTH_BIND_ADDR_ENV: &str = "AURA_HISTORIA_WORKER_HEALTH_BIND_ADDR";
+const DEFAULT_WORKER_HEALTH_BIND_ADDR: &str = "0.0.0.0:8081";
+const REQUEST_BUFFER_BYTES: usize = 8192;
+
+pub trait WorkerJob: Send + 'static {}
+
+impl<T> WorkerJob for T where T: Send + 'static {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerConfig {
+    health_bind_addr: SocketAddr,
+}
+
+impl WorkerConfig {
+    pub fn from_env() -> Result<Self, WorkerConfigError> {
+        Self::from_getter(|name| std::env::var(name).ok())
+    }
+
+    pub fn from_getter<F>(mut get: F) -> Result<Self, WorkerConfigError>
+    where
+        F: FnMut(&'static str) -> Option<String>,
+    {
+        let raw_health_bind_addr = get(WORKER_HEALTH_BIND_ADDR_ENV)
+            .unwrap_or_else(|| DEFAULT_WORKER_HEALTH_BIND_ADDR.to_owned());
+        let health_bind_addr = raw_health_bind_addr.parse().map_err(|source| {
+            WorkerConfigError::InvalidHealthBindAddr {
+                value: raw_health_bind_addr,
+                source,
+            }
+        })?;
+
+        Ok(Self { health_bind_addr })
+    }
+
+    pub const fn health_bind_addr(&self) -> SocketAddr {
+        self.health_bind_addr
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum WorkerConfigError {
+    #[error("invalid {env_name}: {value}", env_name = WORKER_HEALTH_BIND_ADDR_ENV)]
+    InvalidHealthBindAddr {
+        value: String,
+        source: AddrParseError,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueueConfig {
+    capacity: usize,
+}
+
+impl QueueConfig {
+    pub const fn new(capacity: usize) -> Self {
+        Self { capacity }
+    }
+
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InMemoryQueueSender<T> {
+    sender: mpsc::Sender<T>,
+}
+
+#[derive(Debug)]
+pub struct InMemoryQueueReceiver<T> {
+    receiver: mpsc::Receiver<T>,
+}
+
+pub fn in_memory_queue<T>(
+    config: QueueConfig,
+) -> Result<(InMemoryQueueSender<T>, InMemoryQueueReceiver<T>), QueueConfigError>
+where
+    T: WorkerJob,
+{
+    if config.capacity() == 0 {
+        return Err(QueueConfigError::InvalidCapacity);
+    }
+
+    let (sender, receiver) = mpsc::channel(config.capacity());
+    Ok((
+        InMemoryQueueSender { sender },
+        InMemoryQueueReceiver { receiver },
+    ))
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum QueueConfigError {
+    #[error("queue capacity must be greater than zero")]
+    InvalidCapacity,
+}
+
+impl<T> InMemoryQueueSender<T>
+where
+    T: WorkerJob,
+{
+    pub async fn enqueue(&self, job: T) -> Result<(), mpsc::error::SendError<T>> {
+        self.sender.send(job).await
+    }
+
+    pub fn try_enqueue(&self, job: T) -> Result<(), mpsc::error::TrySendError<T>> {
+        self.sender.try_send(job)
+    }
+}
+
+impl<T> InMemoryQueueReceiver<T>
+where
+    T: WorkerJob,
+{
+    pub async fn recv(&mut self) -> Option<T> {
+        self.receiver.recv().await
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthResponse {
+    pub status_code: u16,
+    pub body: &'static str,
+}
+
+pub fn route(method: &str, path: &str) -> HealthResponse {
+    match (method, path) {
+        ("GET", "/health") => HealthResponse {
+            status_code: 200,
+            body: "ok\n",
+        },
+        ("GET", "/ready") => HealthResponse {
+            status_code: 200,
+            body: "ready\n",
+        },
+        _ => HealthResponse {
+            status_code: 404,
+            body: "not found\n",
+        },
+    }
+}
+
+pub async fn run_until_shutdown<S>(config: WorkerConfig, shutdown: S) -> Result<(), WorkerRunError>
+where
+    S: Future<Output = ()>,
+{
+    let listener = TcpListener::bind(config.health_bind_addr())
+        .await
+        .map_err(WorkerRunError::Bind)?;
+    serve(listener, shutdown).await
+}
+
+pub async fn serve<S>(listener: TcpListener, shutdown: S) -> Result<(), WorkerRunError>
+where
+    S: Future<Output = ()>,
+{
+    let local_addr = listener.local_addr().map_err(WorkerRunError::LocalAddr)?;
+    info!(bind_addr = %local_addr, "aura-historia-worker health server listening");
+    tokio::pin!(shutdown);
+
+    loop {
+        tokio::select! {
+            accept_result = listener.accept() => {
+                let (stream, peer_addr) = accept_result.map_err(WorkerRunError::Accept)?;
+                debug!(%peer_addr, "accepted worker health connection");
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(stream).await {
+                        error!(%error, "worker health connection failed");
+                    }
+                });
+            }
+            () = &mut shutdown => {
+                info!("aura-historia-worker shutdown requested");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn handle_connection(mut stream: TcpStream) -> Result<(), std::io::Error> {
+    let mut buffer = [0_u8; REQUEST_BUFFER_BYTES];
+    let bytes_read = stream.read(&mut buffer).await?;
+    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let (method, path) = parse_request_line(&request).unwrap_or(("", ""));
+    let response = route(method, path);
+    write_response(&mut stream, response).await
+}
+
+fn parse_request_line(request: &str) -> Option<(&str, &str)> {
+    let line = request.lines().next()?;
+    let mut parts = line.split_whitespace();
+    let method = parts.next()?;
+    let path = parts.next()?;
+    Some((method, path))
+}
+
+async fn write_response(
+    stream: &mut TcpStream,
+    response: HealthResponse,
+) -> Result<(), std::io::Error> {
+    let status = match response.status_code {
+        200 => "200 OK",
+        404 => "404 Not Found",
+        _ => "500 Internal Server Error",
+    };
+    let bytes = response.body.as_bytes();
+    stream
+        .write_all(
+            format!(
+                "HTTP/1.1 {status}\r\ncontent-length: {}\r\ncontent-type: text/plain\r\nconnection: close\r\n\r\n{}",
+                bytes.len(),
+                response.body
+            )
+            .as_bytes(),
+        )
+        .await
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum WorkerRunError {
+    #[error("failed to bind worker health listener")]
+    Bind(#[source] std::io::Error),
+    #[error("failed to read worker health listener local address")]
+    LocalAddr(#[source] std::io::Error),
+    #[error("failed to accept worker health connection")]
+    Accept(#[source] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+
+    use super::*;
+    use rstest::rstest;
+    use tokio::sync::oneshot;
+
+    fn env(values: &[(&'static str, &str)]) -> HashMap<&'static str, String> {
+        values
+            .iter()
+            .map(|(key, value)| (*key, (*value).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn should_use_default_health_bind_addr_when_env_missing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let values = env(&[]);
+
+        let config = WorkerConfig::from_getter(|name| values.get(name).cloned())?;
+
+        assert_eq!(
+            "0.0.0.0:8081".parse::<SocketAddr>()?,
+            config.health_bind_addr()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_read_health_bind_addr_from_env() -> Result<(), Box<dyn std::error::Error>> {
+        let values = env(&[(WORKER_HEALTH_BIND_ADDR_ENV, "127.0.0.1:9001")]);
+
+        let config = WorkerConfig::from_getter(|name| values.get(name).cloned())?;
+
+        assert_eq!(
+            "127.0.0.1:9001".parse::<SocketAddr>()?,
+            config.health_bind_addr()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_fail_when_health_bind_addr_is_invalid() {
+        let values = env(&[(WORKER_HEALTH_BIND_ADDR_ENV, "not-an-addr")]);
+
+        let config = WorkerConfig::from_getter(|name| values.get(name).cloned());
+
+        assert!(matches!(
+            config,
+            Err(WorkerConfigError::InvalidHealthBindAddr { .. })
+        ));
+    }
+
+    #[rstest]
+    #[case("GET", "/health", 200, "ok\n")]
+    #[case("GET", "/ready", 200, "ready\n")]
+    #[case("POST", "/health", 404, "not found\n")]
+    fn should_route_health_endpoints(
+        #[case] method: &str,
+        #[case] path: &str,
+        #[case] status_code: u16,
+        #[case] body: &'static str,
+    ) {
+        let response = route(method, path);
+
+        assert_eq!(status_code, response.status_code);
+        assert_eq!(body, response.body);
+    }
+
+    #[tokio::test]
+    async fn should_enqueue_and_receive_jobs() -> Result<(), Box<dyn std::error::Error>> {
+        let (sender, mut receiver) = in_memory_queue::<String>(QueueConfig::new(2))?;
+
+        sender.enqueue("product:1".to_owned()).await?;
+
+        assert_eq!(Some("product:1".to_owned()), receiver.recv().await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_apply_backpressure_when_queue_is_full() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (sender, _receiver) = in_memory_queue::<String>(QueueConfig::new(1))?;
+
+        let first_result = sender.try_enqueue("product:1".to_owned());
+        let second_result = sender.try_enqueue("product:2".to_owned());
+
+        assert!(first_result.is_ok());
+        assert!(matches!(
+            second_result,
+            Err(mpsc::error::TrySendError::Full(_))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn should_reject_zero_queue_capacity() {
+        let queue = in_memory_queue::<String>(QueueConfig::new(0));
+
+        assert!(matches!(queue, Err(QueueConfigError::InvalidCapacity)));
+    }
+
+    #[tokio::test]
+    async fn should_serve_health_endpoint_until_shutdown() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(serve(listener, async move {
+            let _ = shutdown_rx.await;
+        }));
+
+        let mut stream = TcpStream::connect(addr).await?;
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nhost: localhost\r\n\r\n")
+            .await?;
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await?;
+        let _send_result = shutdown_tx.send(());
+        server.await??;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.ends_with("ok\n"));
+        Ok(())
+    }
+}

--- a/src/aura-historia-worker/src/main.rs
+++ b/src/aura-historia-worker/src/main.rs
@@ -1,0 +1,23 @@
+use aura_historia_worker::{WorkerConfig, WorkerConfigError, WorkerRunError, run_until_shutdown};
+
+#[tokio::main]
+async fn main() -> Result<(), MainError> {
+    common::logging::init_logging();
+    let config = WorkerConfig::from_env()?;
+    run_until_shutdown(config, shutdown_signal()).await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        tracing::error!(%error, "failed to listen for shutdown signal");
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum MainError {
+    #[error(transparent)]
+    Config(#[from] WorkerConfigError),
+    #[error(transparent)]
+    Run(#[from] WorkerRunError),
+}


### PR DESCRIPTION
Closes #1371
Closes #1373
Parent: #1341

## Intent

Create native bare-metal runtime entrypoints for the Hetzner migration, without API Gateway glue or AWS worker runtime coupling.

## Summary

- Add `aura-historia-api` with thin bootstrap, bind-address config, graceful shutdown, and `/health` + `/ready` HTTP endpoints.
- Add `aura-historia-worker` with thin bootstrap, worker health server, and bounded in-memory queue primitives.
- Wire both crates into the workspace and DOX child index.

## Breaking changes

- None. New crates only.

## Behavior impact

- API runtime listens on `AURA_HISTORIA_API_BIND_ADDR`, default `0.0.0.0:8080`.
- Worker health endpoint listens on `AURA_HISTORIA_WORKER_HEALTH_BIND_ADDR`, default `0.0.0.0:8081`.
- Worker queues are in-memory only; future CDC fan-out/sub-workers can build on the abstraction.

## Risk

- Minimal runtime server is intentionally small and only suitable for skeleton health checks. Real routing/auth/HTTP middleware should be added in later issues before production use.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p aura-historia-api`
- `cargo test -p aura-historia-api --all-features`
- `cargo check -p aura-historia-worker`
- `cargo test -p aura-historia-worker --all-features`
