### PR TITLE
task(#1374, #1375): add worker CDC fanout core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,8 @@ version = "0.1.0"
 dependencies = [
  "common",
  "rstest",
+ "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8158,6 +8158,7 @@ name = "test-api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aura-historia-worker",
  "aws-config",
  "aws-sdk-account",
  "aws-sdk-cloudformation",
@@ -8170,6 +8171,7 @@ dependencies = [
  "aws-sdk-sqs",
  "aws-tests-common",
  "aws_lambda_events",
+ "base64 0.23.0",
  "common",
  "ctrlc",
  "derive_builder",

--- a/docs/events/flow.md
+++ b/docs/events/flow.md
@@ -103,6 +103,8 @@ No intermediate product command SQS queue. No `202 accepted because queued` beha
 
 ## Sequin fanout contract
 
+`aura-historia-worker` exposes `POST /cdc/sequin` for CDC delivery.
+
 There is no durable `worker_inbox` table.
 
 Minimum ingest steps:
@@ -113,7 +115,8 @@ Minimum ingest steps:
 4. Derive domain-first `idempotency_key` and `ordering_key`.
 5. Map change to one or more domain jobs.
 6. Enqueue every job to every relevant bounded in-memory queue.
-7. Ack Sequin only after all enqueue operations succeed.
+7. Return `202` to Sequin only after all enqueue operations succeed.
+8. Return non-2xx when fanout fails so Sequin retries.
 
 Crash rule:
 
@@ -123,17 +126,17 @@ Crash rule:
 - MVP accepts this risk.
 - No scheduled inconsistency checker or repair job is part of v1.
 
-## CDC routing draft
+## CDC routing
 
 | Source table | Operation | Route |
 |---|---|---|
 | `product_events` | INSERT | Product projector; percolator for domain/enrichment; watchlist notifications for price/state; enrichment pipeline for create/embed; delete cleanup for lifecycle delete. |
-| `products` | INSERT/MODIFY | No default downstream route. Product events are the projection trigger to avoid double-firing. Use products CDC only for future explicit non-event projections. |
-| `shops` | INSERT/MODIFY/DELETE | Shop OpenSearch projector. Domains are inline in `shops.shop_domains`. |
-| `search_filters` | INSERT/MODIFY/DELETE | Search-filter OpenSearch sync; user tier checks if state/feature-relevant. |
-| `search_filter_matches` | INSERT/MODIFY/DELETE | Usually no downstream route except observability. `origin_event_id` links to `product_events.event_id`. |
-| `users` | INSERT/MODIFY/DELETE | User tier enforcement for tier changes; no user OpenSearch projection. |
-| `product_watchlist` | INSERT/MODIFY/DELETE | Usually no downstream route except tier enforcement; product events drive notifications. |
+| `products` | INSERT/MODIFY/DELETE | No default downstream route. Product events are the projection trigger to avoid double-firing. Use products CDC only for future explicit non-event projections. |
+| `shops` | INSERT/MODIFY/DELETE | Shop OpenSearch projector. Domains are inline in `shops.shop_domains`. Idempotency: `(shop_id, version, op)`. |
+| `search_filters` | INSERT/MODIFY/DELETE | Search-filter OpenSearch sync for search/embedding/language/currency/state/notifications changes. Idempotency: `(user_search_filter_id, version, op)`. |
+| `search_filter_matches` | INSERT/MODIFY/DELETE | No default downstream route. `origin_event_id` links to `product_events.event_id`. |
+| `users` | MODIFY | User tier enforcement for tier changes; no user OpenSearch projection. Idempotency: `(user_id, version)`. |
+| `product_watchlist` | INSERT/MODIFY/DELETE | No default downstream route; product events drive notifications. |
 | `partner_shop_applications` | INSERT/MODIFY | No generic worker route unless notification behavior requires it. |
 
 ## Domain jobs
@@ -207,7 +210,7 @@ MVP has no worker-owned Postgres tables.
 - No dead-letter table.
 - No scheduled inconsistency checker or repair job.
 
-Sub-workers may retry transient failures while the process is alive. If the process dies after Sequin ack, queued jobs can be lost. This risk is accepted for MVP.
+Sub-workers may retry transient failures while the process is alive. Exhausted retries move to an in-memory DLQ helper for logging/metrics while the process remains alive. If the process dies after Sequin ack, queued or DLQ jobs can be lost. This risk is accepted for MVP.
 
 ## Operations notes
 

--- a/docs/events/flow.md
+++ b/docs/events/flow.md
@@ -143,6 +143,8 @@ Crash rule:
 
 Worker sub-jobs use domain payloads or compact IDs. They do not use DynamoDB stream records and should not depend on raw Sequin JSON outside the router.
 
+Current router jobs carry compact domain refs. Sub-worker implementation issues must introduce typed DTOs/payloads where behavior depends on event/change fields. Those DTOs should be derived from Postgres/domain rows, not from Sequin envelopes.
+
 Examples:
 
 - `ProductEventJob`
@@ -220,5 +222,6 @@ Postgres is business truth and Sequin depends on replication health. Production 
 
 - Use Postgres integration tests for repositories.
 - Use fake CDC envelopes for router fanout tests.
+- Use `test-api` Sequin helpers for real Sequin webhook delivery tests when CDC behavior matters.
 - Use existing LocalStack OpenSearch for projection/percolator tests.
 - Keep DynamoDB and CDK/CloudFormation helpers for AWS survivor tests.

--- a/src/aura-historia-worker/AGENTS.md
+++ b/src/aura-historia-worker/AGENTS.md
@@ -8,7 +8,7 @@
 
 - `main.rs` bootstraps logging, config, health/CDC server, and graceful shutdown.
 - `lib.rs` owns runtime config, `/health`, `/ready`, `/cdc/sequin`, server loop, and bounded queue primitives.
-- `cdc.rs` normalizes Sequin JSON to domain jobs and fans out after route validation.
+- `cdc.rs` normalizes Sequin webhook JSON to domain jobs and fans out after route validation.
 - `retry.rs` owns in-process retry, idempotency memory, and in-memory DLQ helpers.
 - No worker persistence tables in MVP. Crash after CDC fan-out may lose queued jobs.
 
@@ -27,6 +27,7 @@
 
 - Keep runtime glue thin.
 - Queue payloads should be domain types or domain IDs, not Sequin/AWS envelopes.
+- Sub-worker implementation must extract typed DTOs/payloads from Postgres/domain rows when behavior needs event/change fields; do not consume raw Sequin JSON outside router.
 - Ack Sequin only after all relevant bounded queue enqueues succeed.
 - Use domain idempotency keys; Sequin IDs/LSNs are logs only.
 - Keep queue abstraction replaceable by SQS/Lambda/ECS later.

--- a/src/aura-historia-worker/AGENTS.md
+++ b/src/aura-historia-worker/AGENTS.md
@@ -2,13 +2,14 @@
 
 ## Purpose
 
-- Own bare-metal async worker runtime skeleton for #1341.
+- Own bare-metal async worker runtime, Sequin CDC ingestion, and in-memory worker queues for #1341.
 
 ## Core Design
 
-- `main.rs` bootstraps logging, config, health server, and graceful shutdown.
-- `lib.rs` owns runtime config, health/readiness endpoints, server loop, and bounded in-memory queue primitives.
-- Worker consumes future Sequin CDC, routes domain changes to in-memory queues, then sub-workers handle retries/DLQ in process.
+- `main.rs` bootstraps logging, config, health/CDC server, and graceful shutdown.
+- `lib.rs` owns runtime config, `/health`, `/ready`, `/cdc/sequin`, server loop, and bounded queue primitives.
+- `cdc.rs` normalizes Sequin JSON to domain jobs and fans out after route validation.
+- `retry.rs` owns in-process retry, idempotency memory, and in-memory DLQ helpers.
 - No worker persistence tables in MVP. Crash after CDC fan-out may lose queued jobs.
 
 ## Ownership
@@ -26,6 +27,8 @@
 
 - Keep runtime glue thin.
 - Queue payloads should be domain types or domain IDs, not Sequin/AWS envelopes.
+- Ack Sequin only after all relevant bounded queue enqueues succeed.
+- Use domain idempotency keys; Sequin IDs/LSNs are logs only.
 - Keep queue abstraction replaceable by SQS/Lambda/ECS later.
 
 ## Verification

--- a/src/aura-historia-worker/AGENTS.md
+++ b/src/aura-historia-worker/AGENTS.md
@@ -7,7 +7,7 @@
 ## Core Design
 
 - `main.rs` bootstraps logging, config, health/CDC server, and graceful shutdown.
-- `lib.rs` owns runtime config, `/health`, `/ready`, `/cdc/sequin`, server loop, and bounded queue primitives.
+- `lib.rs` owns runtime config, `/health`, `/ready`, `/cdc/sequin`, server loop, default all-queue runtime, and bounded queue primitives.
 - `cdc.rs` normalizes Sequin webhook JSON to domain jobs and fans out after route validation.
 - `retry.rs` owns in-process retry, idempotency memory, and in-memory DLQ helpers.
 - No worker persistence tables in MVP. Crash after CDC fan-out may lose queued jobs.
@@ -26,6 +26,7 @@
 ## Work Guidance
 
 - Keep runtime glue thin.
+- Register all known worker queues by default; tests and runtime code should not hand-register only a subset unless testing missing-queue failure.
 - Queue payloads should be domain types or domain IDs, not Sequin/AWS envelopes.
 - Sub-worker implementation must extract typed DTOs/payloads from Postgres/domain rows when behavior needs event/change fields; do not consume raw Sequin JSON outside router.
 - Ack Sequin only after all relevant bounded queue enqueues succeed.

--- a/src/aura-historia-worker/Cargo.toml
+++ b/src/aura-historia-worker/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2024"
 
 [dependencies]
 common = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/src/aura-historia-worker/src/cdc.rs
+++ b/src/aura-historia-worker/src/cdc.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
@@ -223,7 +223,7 @@ impl CdcFanout {
     }
 
     pub async fn ingest_json(&self, body: &str) -> Result<usize, CdcIngestError> {
-        let batch: CdcBatch = serde_json::from_str(body).map_err(CdcIngestError::InvalidJson)?;
+        let batch = parse_cdc_batch(body).map_err(CdcIngestError::InvalidJson)?;
         self.ingest_batch(&batch).await
     }
 
@@ -243,6 +243,90 @@ impl CdcFanout {
         );
         Ok(enqueued)
     }
+}
+
+fn parse_cdc_batch(body: &str) -> Result<CdcBatch, serde_json::Error> {
+    let value: Value = serde_json::from_str(body)?;
+
+    if value.get("data").is_some() {
+        return serde_json::from_value::<SequinWebhookBatch>(value).map(Into::into);
+    }
+
+    if value.get("metadata").is_some() && value.get("record").is_some() {
+        return serde_json::from_value::<SequinWebhookMessage>(value).map(CdcBatch::from);
+    }
+
+    serde_json::from_value(value)
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+struct SequinWebhookBatch {
+    data: Vec<SequinWebhookMessage>,
+}
+
+impl From<SequinWebhookBatch> for CdcBatch {
+    fn from(batch: SequinWebhookBatch) -> Self {
+        Self {
+            delivery_id: None,
+            source: Some("sequin-webhook".to_owned()),
+            changes: batch.data.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+struct SequinWebhookMessage {
+    record: Option<Value>,
+    #[serde(default)]
+    changes: Option<Map<String, Value>>,
+    #[serde(deserialize_with = "deserialize_operation")]
+    action: CdcOperation,
+    metadata: SequinWebhookMetadata,
+}
+
+impl From<SequinWebhookMessage> for CdcBatch {
+    fn from(message: SequinWebhookMessage) -> Self {
+        Self {
+            delivery_id: None,
+            source: Some("sequin-webhook".to_owned()),
+            changes: vec![message.into()],
+        }
+    }
+}
+
+impl From<SequinWebhookMessage> for CdcChange {
+    fn from(message: SequinWebhookMessage) -> Self {
+        let changed_columns = message
+            .changes
+            .as_ref()
+            .map(|changes| changes.keys().cloned().collect())
+            .unwrap_or_default();
+
+        Self {
+            schema: Some(message.metadata.table_schema),
+            table: message.metadata.table_name,
+            operation: message.action,
+            primary_key: BTreeMap::new(),
+            record: message.record,
+            old_record: message.changes.map(Value::Object),
+            changed_columns,
+            commit_lsn: message.metadata.commit_lsn.map(|value| match value {
+                Value::String(value) => value,
+                other => other.to_string(),
+            }),
+            commit_timestamp: message.metadata.commit_timestamp,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+struct SequinWebhookMetadata {
+    table_schema: String,
+    table_name: String,
+    #[serde(default)]
+    commit_lsn: Option<Value>,
+    #[serde(default)]
+    commit_timestamp: Option<String>,
 }
 
 pub fn route_change(change: &CdcChange) -> Result<Vec<DomainJob>, CdcRouteError> {
@@ -817,7 +901,7 @@ mod tests {
 
     #[test]
     fn should_parse_sequin_like_json_with_aliases() -> Result<(), Box<dyn std::error::Error>> {
-        let batch: CdcBatch = serde_json::from_str(
+        let batch = parse_cdc_batch(
             r#"{
                 "id": "delivery-1",
                 "source": "postgres",
@@ -841,6 +925,63 @@ mod tests {
         assert_eq!(Some("delivery-1".to_owned()), batch.delivery_id);
         assert_eq!(1, batch.changes.len());
         assert_eq!(CdcOperation::Insert, batch.changes[0].operation);
+        Ok(())
+    }
+
+    #[test]
+    fn should_parse_real_sequin_webhook_message() -> Result<(), Box<dyn std::error::Error>> {
+        let batch = parse_cdc_batch(
+            r#"{
+                "record": {
+                    "event_id": "40000000-0000-0000-0000-000000000001",
+                    "product_id": "30000000-0000-0000-0000-000000000001",
+                    "event_type": "PRODUCT_CREATED",
+                    "event_group": "DOMAIN"
+                },
+                "changes": null,
+                "action": "insert",
+                "metadata": {
+                    "table_schema": "public",
+                    "table_name": "product_events",
+                    "commit_timestamp": "2026-07-25T12:00:00Z",
+                    "commit_lsn": 123456789
+                }
+            }"#,
+        )?;
+
+        assert_eq!(Some("sequin-webhook".to_owned()), batch.source);
+        assert_eq!(1, batch.changes.len());
+        assert_eq!("product_events", batch.changes[0].table);
+        assert_eq!(CdcOperation::Insert, batch.changes[0].operation);
+        assert_eq!(Some("123456789".to_owned()), batch.changes[0].commit_lsn);
+        Ok(())
+    }
+
+    #[test]
+    fn should_parse_real_sequin_webhook_batch() -> Result<(), Box<dyn std::error::Error>> {
+        let batch = parse_cdc_batch(
+            r#"{
+                "data": [
+                    {
+                        "record": {
+                            "user_id": "10000000-0000-0000-0000-000000000001",
+                            "tier": "PREMIUM",
+                            "version": 2
+                        },
+                        "changes": { "tier": "FREE" },
+                        "action": "update",
+                        "metadata": {
+                            "table_schema": "public",
+                            "table_name": "users"
+                        }
+                    }
+                ]
+            }"#,
+        )?;
+
+        assert_eq!(1, batch.changes.len());
+        assert_eq!("users", batch.changes[0].table);
+        assert_eq!(vec!["tier".to_owned()], batch.changes[0].changed_columns);
         Ok(())
     }
 }

--- a/src/aura-historia-worker/src/cdc.rs
+++ b/src/aura-historia-worker/src/cdc.rs
@@ -7,7 +7,9 @@ use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
-use crate::InMemoryQueueSender;
+use crate::{
+    InMemoryQueueReceiver, InMemoryQueueSender, QueueConfig, QueueConfigError, in_memory_queue,
+};
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct CdcBatch {
@@ -50,6 +52,20 @@ pub enum CdcOperation {
     Insert,
     Update,
     Delete,
+}
+
+impl WorkerQueue {
+    pub const ALL: [Self; 9] = [
+        Self::ProductOpenSearch,
+        Self::ProductDeleteCleanup,
+        Self::WatchlistNotification,
+        Self::SearchFilterPercolator,
+        Self::ProductEmbed,
+        Self::ProductTranslate,
+        Self::ShopOpenSearch,
+        Self::SearchFilterOpenSearch,
+        Self::UserTierEnforcement,
+    ];
 }
 
 impl Display for CdcOperation {
@@ -192,6 +208,21 @@ impl WorkerQueueRegistry {
         Self::default()
     }
 
+    pub fn with_all_queues(
+        config: QueueConfig,
+    ) -> Result<(Self, WorkerQueueReceivers), QueueConfigError> {
+        let mut registry = Self::new();
+        let mut receivers = WorkerQueueReceivers::new();
+
+        for queue in WorkerQueue::ALL {
+            let (sender, receiver) = in_memory_queue::<DomainJob>(config)?;
+            registry = registry.with_queue(queue, sender);
+            receivers.insert(queue, receiver);
+        }
+
+        Ok((registry, receivers))
+    }
+
     pub fn with_queue(
         mut self,
         queue: WorkerQueue,
@@ -209,6 +240,33 @@ impl WorkerQueueRegistry {
             .enqueue(job)
             .await
             .map_err(|error| CdcFanoutError::QueueClosed(error.0.target_queue))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct WorkerQueueReceivers {
+    receivers: HashMap<WorkerQueue, InMemoryQueueReceiver<DomainJob>>,
+}
+
+impl WorkerQueueReceivers {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&mut self, queue: WorkerQueue, receiver: InMemoryQueueReceiver<DomainJob>) {
+        self.receivers.insert(queue, receiver);
+    }
+
+    pub async fn recv(&mut self, queue: WorkerQueue) -> Option<DomainJob> {
+        self.receivers.get_mut(&queue)?.recv().await
+    }
+
+    pub async fn recv_timeout(
+        &mut self,
+        queue: WorkerQueue,
+        duration: std::time::Duration,
+    ) -> Result<Option<DomainJob>, tokio::time::error::Elapsed> {
+        tokio::time::timeout(duration, self.recv(queue)).await
     }
 }
 

--- a/src/aura-historia-worker/src/cdc.rs
+++ b/src/aura-historia-worker/src/cdc.rs
@@ -1,0 +1,846 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::InMemoryQueueSender;
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct CdcBatch {
+    #[serde(default, alias = "id", alias = "webhook_id")]
+    pub delivery_id: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default, alias = "events", alias = "records")]
+    pub changes: Vec<CdcChange>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct CdcChange {
+    #[serde(default, alias = "table_schema")]
+    pub schema: Option<String>,
+    #[serde(alias = "relation")]
+    pub table: String,
+    #[serde(
+        alias = "op",
+        alias = "action",
+        deserialize_with = "deserialize_operation"
+    )]
+    pub operation: CdcOperation,
+    #[serde(default, alias = "keys")]
+    pub primary_key: BTreeMap<String, Value>,
+    #[serde(default, alias = "new", alias = "new_record")]
+    pub record: Option<Value>,
+    #[serde(default, rename = "old", alias = "old_record", alias = "previous")]
+    pub old_record: Option<Value>,
+    #[serde(default, alias = "changed")]
+    pub changed_columns: Vec<String>,
+    #[serde(default)]
+    pub commit_lsn: Option<String>,
+    #[serde(default)]
+    pub commit_timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CdcOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+impl Display for CdcOperation {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CdcOperation::Insert => write!(formatter, "insert"),
+            CdcOperation::Update => write!(formatter, "update"),
+            CdcOperation::Delete => write!(formatter, "delete"),
+        }
+    }
+}
+
+impl FromStr for CdcOperation {
+    type Err = CdcOperationParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "insert" | "create" => Ok(Self::Insert),
+            "update" | "modify" => Ok(Self::Update),
+            "delete" | "remove" => Ok(Self::Delete),
+            _ => Err(CdcOperationParseError {
+                value: value.to_owned(),
+            }),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+#[error("unsupported CDC operation: {value}")]
+pub struct CdcOperationParseError {
+    value: String,
+}
+
+fn deserialize_operation<'de, D>(deserializer: D) -> Result<CdcOperation, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    CdcOperation::from_str(&value).map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomainJob {
+    pub target_queue: WorkerQueue,
+    pub idempotency_key: IdempotencyKey,
+    pub ordering_key: OrderingKey,
+    pub payload: DomainJobPayload,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WorkerQueue {
+    ProductOpenSearch,
+    ProductDeleteCleanup,
+    WatchlistNotification,
+    SearchFilterPercolator,
+    ProductEmbed,
+    ProductTranslate,
+    ShopOpenSearch,
+    SearchFilterOpenSearch,
+    UserTierEnforcement,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IdempotencyKey(String);
+
+impl IdempotencyKey {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OrderingKey(String);
+
+impl OrderingKey {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DomainJobPayload {
+    ProductEvent(ProductEventJob),
+    ProductDelete(ProductDeleteJob),
+    ShopChanged(ShopChangedJob),
+    SearchFilterChanged(SearchFilterChangedJob),
+    UserTierChanged(UserTierChangedJob),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductEventJob {
+    pub event_id: String,
+    pub product_id: String,
+    pub event_type: String,
+    pub event_group: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductDeleteJob {
+    pub event_id: String,
+    pub product_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShopChangedJob {
+    pub shop_id: String,
+    pub version: i64,
+    pub operation: CdcOperation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchFilterChangedJob {
+    pub user_id: String,
+    pub user_search_filter_id: String,
+    pub version: i64,
+    pub operation: CdcOperation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserTierChangedJob {
+    pub user_id: String,
+    pub version: i64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WorkerQueueRegistry {
+    queues: HashMap<WorkerQueue, InMemoryQueueSender<DomainJob>>,
+}
+
+impl WorkerQueueRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_queue(
+        mut self,
+        queue: WorkerQueue,
+        sender: InMemoryQueueSender<DomainJob>,
+    ) -> Self {
+        self.queues.insert(queue, sender);
+        self
+    }
+
+    async fn enqueue(&self, job: DomainJob) -> Result<(), CdcFanoutError> {
+        let Some(sender) = self.queues.get(&job.target_queue) else {
+            return Err(CdcFanoutError::MissingQueue(job.target_queue));
+        };
+        sender
+            .enqueue(job)
+            .await
+            .map_err(|error| CdcFanoutError::QueueClosed(error.0.target_queue))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CdcFanout {
+    registry: WorkerQueueRegistry,
+}
+
+impl CdcFanout {
+    pub fn new(registry: WorkerQueueRegistry) -> Self {
+        Self { registry }
+    }
+
+    pub async fn ingest_json(&self, body: &str) -> Result<usize, CdcIngestError> {
+        let batch: CdcBatch = serde_json::from_str(body).map_err(CdcIngestError::InvalidJson)?;
+        self.ingest_batch(&batch).await
+    }
+
+    pub async fn ingest_batch(&self, batch: &CdcBatch) -> Result<usize, CdcIngestError> {
+        let mut enqueued = 0;
+
+        for change in &batch.changes {
+            for job in route_change(change)? {
+                self.registry.enqueue(job).await?;
+                enqueued += 1;
+            }
+        }
+
+        debug!(
+            changes = batch.changes.len(),
+            enqueued, "CDC batch fanned out"
+        );
+        Ok(enqueued)
+    }
+}
+
+pub fn route_change(change: &CdcChange) -> Result<Vec<DomainJob>, CdcRouteError> {
+    let table = CdcTable::from(change.table.as_str());
+    match (table, change.operation) {
+        (CdcTable::ProductEvents, CdcOperation::Insert) => product_event_jobs(change),
+        (CdcTable::ProductEvents, _) => Ok(Vec::new()),
+        (CdcTable::Shops, operation) => shop_changed_job(change, operation),
+        (CdcTable::SearchFilters, operation) => search_filter_changed_job(change, operation),
+        (CdcTable::Users, CdcOperation::Update) => user_tier_changed_job(change),
+        (CdcTable::Users, _) => Ok(Vec::new()),
+        (CdcTable::Unknown(table), _) => {
+            warn!(%table, operation = %change.operation, "ignoring unregistered CDC table");
+            Ok(Vec::new())
+        }
+        (
+            CdcTable::Products
+            | CdcTable::ProductWatchlist
+            | CdcTable::SearchFilterMatches
+            | CdcTable::UserPartnerShops
+            | CdcTable::PartnerShopApplications,
+            _,
+        ) => Ok(Vec::new()),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CdcTable {
+    ProductEvents,
+    Products,
+    Shops,
+    SearchFilters,
+    SearchFilterMatches,
+    Users,
+    ProductWatchlist,
+    UserPartnerShops,
+    PartnerShopApplications,
+    Unknown(String),
+}
+
+impl From<&str> for CdcTable {
+    fn from(value: &str) -> Self {
+        match value {
+            "product_events" => Self::ProductEvents,
+            "products" => Self::Products,
+            "shops" => Self::Shops,
+            "search_filters" => Self::SearchFilters,
+            "search_filter_matches" => Self::SearchFilterMatches,
+            "users" => Self::Users,
+            "product_watchlist" => Self::ProductWatchlist,
+            "user_partner_shops" => Self::UserPartnerShops,
+            "partner_shop_applications" => Self::PartnerShopApplications,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+}
+
+fn product_event_jobs(change: &CdcChange) -> Result<Vec<DomainJob>, CdcRouteError> {
+    let row = required_row(change)?;
+    let event_id = required_string(row, "event_id")?;
+    let product_id = required_string(row, "product_id")?;
+    let event_type = required_string(row, "event_type")?;
+    let event_group = required_string(row, "event_group")?;
+    let base_job = ProductEventJob {
+        event_id: event_id.clone(),
+        product_id: product_id.clone(),
+        event_type: event_type.clone(),
+        event_group: event_group.clone(),
+    };
+    let idempotency_key = IdempotencyKey::new(format!("product-event:{event_id}"));
+    let ordering_key = OrderingKey::new(format!("product:{product_id}"));
+
+    let mut jobs = vec![domain_job(
+        WorkerQueue::ProductOpenSearch,
+        idempotency_key.clone(),
+        ordering_key.clone(),
+        DomainJobPayload::ProductEvent(base_job.clone()),
+    )];
+
+    if matches!(event_group.as_str(), "DOMAIN" | "ENRICHMENT") {
+        jobs.push(domain_job(
+            WorkerQueue::SearchFilterPercolator,
+            idempotency_key.clone(),
+            ordering_key.clone(),
+            DomainJobPayload::ProductEvent(base_job.clone()),
+        ));
+    }
+
+    if matches!(
+        event_type.as_str(),
+        "DOMAIN_PRICE_CHANGED" | "DOMAIN_STATE_CHANGED"
+    ) {
+        jobs.push(domain_job(
+            WorkerQueue::WatchlistNotification,
+            idempotency_key.clone(),
+            ordering_key.clone(),
+            DomainJobPayload::ProductEvent(base_job.clone()),
+        ));
+    }
+
+    if event_type == "DOMAIN_CREATED" {
+        jobs.push(domain_job(
+            WorkerQueue::ProductEmbed,
+            idempotency_key.clone(),
+            ordering_key.clone(),
+            DomainJobPayload::ProductEvent(base_job.clone()),
+        ));
+    }
+
+    if event_type == "ENRICHMENT_EMBEDDED" {
+        jobs.push(domain_job(
+            WorkerQueue::ProductTranslate,
+            idempotency_key.clone(),
+            ordering_key.clone(),
+            DomainJobPayload::ProductEvent(base_job.clone()),
+        ));
+    }
+
+    if event_type == "LIFECYCLE_DELETED" {
+        jobs.push(domain_job(
+            WorkerQueue::ProductDeleteCleanup,
+            idempotency_key,
+            ordering_key,
+            DomainJobPayload::ProductDelete(ProductDeleteJob {
+                event_id,
+                product_id,
+            }),
+        ));
+    }
+
+    Ok(jobs)
+}
+
+fn shop_changed_job(
+    change: &CdcChange,
+    operation: CdcOperation,
+) -> Result<Vec<DomainJob>, CdcRouteError> {
+    let row = row_for_operation(change)?;
+    let shop_id = required_string(row, "shop_id")?;
+    let version = integer_field(row, "version").unwrap_or(0);
+
+    Ok(vec![domain_job(
+        WorkerQueue::ShopOpenSearch,
+        IdempotencyKey::new(format!("shop:{shop_id}:{version}:{operation}")),
+        OrderingKey::new(format!("shop:{shop_id}")),
+        DomainJobPayload::ShopChanged(ShopChangedJob {
+            shop_id,
+            version,
+            operation,
+        }),
+    )])
+}
+
+fn search_filter_changed_job(
+    change: &CdcChange,
+    operation: CdcOperation,
+) -> Result<Vec<DomainJob>, CdcRouteError> {
+    if operation == CdcOperation::Update
+        && !has_any_changed_column(
+            change,
+            &[
+                "search",
+                "embedding",
+                "language",
+                "currency",
+                "state",
+                "notifications",
+            ],
+        )
+    {
+        return Ok(Vec::new());
+    }
+
+    let row = row_for_operation(change)?;
+    let user_search_filter_id = required_string(row, "user_search_filter_id")?;
+    let user_id = required_string(row, "user_id")?;
+    let version = integer_field(row, "version").unwrap_or(0);
+
+    Ok(vec![domain_job(
+        WorkerQueue::SearchFilterOpenSearch,
+        IdempotencyKey::new(format!(
+            "search-filter:{user_search_filter_id}:{version}:{operation}"
+        )),
+        OrderingKey::new(format!("search-filter:{user_search_filter_id}")),
+        DomainJobPayload::SearchFilterChanged(SearchFilterChangedJob {
+            user_id,
+            user_search_filter_id,
+            version,
+            operation,
+        }),
+    )])
+}
+
+fn user_tier_changed_job(change: &CdcChange) -> Result<Vec<DomainJob>, CdcRouteError> {
+    if !has_tier_change(change) {
+        return Ok(Vec::new());
+    }
+
+    let row = required_row(change)?;
+    let user_id = required_string(row, "user_id")?;
+    let version = integer_field(row, "version").unwrap_or(0);
+
+    Ok(vec![domain_job(
+        WorkerQueue::UserTierEnforcement,
+        IdempotencyKey::new(format!("user-tier:{user_id}:{version}")),
+        OrderingKey::new(format!("user:{user_id}")),
+        DomainJobPayload::UserTierChanged(UserTierChangedJob { user_id, version }),
+    )])
+}
+
+fn domain_job(
+    target_queue: WorkerQueue,
+    idempotency_key: IdempotencyKey,
+    ordering_key: OrderingKey,
+    payload: DomainJobPayload,
+) -> DomainJob {
+    DomainJob {
+        target_queue,
+        idempotency_key,
+        ordering_key,
+        payload,
+    }
+}
+
+fn row_for_operation(change: &CdcChange) -> Result<&Value, CdcRouteError> {
+    match change.operation {
+        CdcOperation::Delete => change.old_record.as_ref().ok_or(CdcRouteError::MissingRow),
+        CdcOperation::Insert | CdcOperation::Update => required_row(change),
+    }
+}
+
+fn required_row(change: &CdcChange) -> Result<&Value, CdcRouteError> {
+    change.record.as_ref().ok_or(CdcRouteError::MissingRow)
+}
+
+fn required_string(row: &Value, field: &'static str) -> Result<String, CdcRouteError> {
+    string_field(row, field).ok_or(CdcRouteError::MissingColumn(field))
+}
+
+fn string_field(row: &Value, field: &str) -> Option<String> {
+    let value = row.get(field)?;
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn integer_field(row: &Value, field: &str) -> Option<i64> {
+    row.get(field)?.as_i64()
+}
+
+fn has_any_changed_column(change: &CdcChange, relevant_columns: &[&str]) -> bool {
+    change.changed_columns.is_empty()
+        || change
+            .changed_columns
+            .iter()
+            .any(|column| relevant_columns.contains(&column.as_str()))
+}
+
+fn has_tier_change(change: &CdcChange) -> bool {
+    if !change.changed_columns.is_empty() {
+        return change.changed_columns.iter().any(|column| column == "tier");
+    }
+
+    let Some(new) = &change.record else {
+        return false;
+    };
+    let Some(old) = &change.old_record else {
+        return true;
+    };
+
+    string_field(new, "tier") != string_field(old, "tier")
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CdcIngestError {
+    #[error("invalid CDC JSON")]
+    InvalidJson(#[source] serde_json::Error),
+    #[error(transparent)]
+    Route(#[from] CdcRouteError),
+    #[error(transparent)]
+    Fanout(#[from] CdcFanoutError),
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum CdcRouteError {
+    #[error("CDC change missing row data")]
+    MissingRow,
+    #[error("CDC row missing required column {0}")]
+    MissingColumn(&'static str),
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum CdcFanoutError {
+    #[error("worker queue is not registered: {0:?}")]
+    MissingQueue(WorkerQueue),
+    #[error("worker queue closed before fanout: {0:?}")]
+    QueueClosed(WorkerQueue),
+}
+
+impl From<mpsc::error::SendError<DomainJob>> for CdcFanoutError {
+    fn from(error: mpsc::error::SendError<DomainJob>) -> Self {
+        Self::QueueClosed(error.0.target_queue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{QueueConfig, in_memory_queue};
+
+    fn product_event_change(event_type: &str, event_group: &str) -> CdcChange {
+        CdcChange {
+            schema: Some("public".to_owned()),
+            table: "product_events".to_owned(),
+            operation: CdcOperation::Insert,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({
+                "event_id": "40000000-0000-0000-0000-000000000001",
+                "product_id": "30000000-0000-0000-0000-000000000001",
+                "event_type": event_type,
+                "event_group": event_group,
+            })),
+            old_record: None,
+            changed_columns: Vec::new(),
+            commit_lsn: None,
+            commit_timestamp: None,
+        }
+    }
+
+    #[test]
+    fn should_route_product_created_event_to_projection_percolator_and_embed()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&product_event_change("DOMAIN_CREATED", "DOMAIN"))?;
+
+        assert_eq!(3, jobs.len());
+        assert!(
+            jobs.iter()
+                .any(|job| job.target_queue == WorkerQueue::ProductOpenSearch)
+        );
+        assert!(
+            jobs.iter()
+                .any(|job| job.target_queue == WorkerQueue::SearchFilterPercolator)
+        );
+        assert!(
+            jobs.iter()
+                .any(|job| job.target_queue == WorkerQueue::ProductEmbed)
+        );
+        assert!(jobs.iter().all(|job| job.idempotency_key.as_str()
+            == "product-event:40000000-0000-0000-0000-000000000001"));
+        assert!(
+            jobs.iter()
+                .all(|job| job.ordering_key.as_str()
+                    == "product:30000000-0000-0000-0000-000000000001")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_route_product_price_event_to_watchlist_notifications()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&product_event_change("DOMAIN_PRICE_CHANGED", "DOMAIN"))?;
+
+        assert!(
+            jobs.iter()
+                .any(|job| job.target_queue == WorkerQueue::WatchlistNotification)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_route_product_delete_event_to_cleanup() -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&product_event_change("LIFECYCLE_DELETED", "LIFECYCLE"))?;
+
+        assert!(
+            jobs.iter()
+                .any(|job| job.target_queue == WorkerQueue::ProductDeleteCleanup)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_ignore_products_table_to_avoid_double_fire() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let jobs = route_change(&CdcChange {
+            schema: Some("public".to_owned()),
+            table: "products".to_owned(),
+            operation: CdcOperation::Update,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({ "product_id": "p1" })),
+            old_record: None,
+            changed_columns: Vec::new(),
+            commit_lsn: None,
+            commit_timestamp: None,
+        })?;
+
+        assert!(jobs.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn should_route_shop_change_with_domain_id_version_key()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&CdcChange {
+            schema: Some("public".to_owned()),
+            table: "shops".to_owned(),
+            operation: CdcOperation::Update,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({
+                "shop_id": "20000000-0000-0000-0000-000000000001",
+                "version": 7,
+            })),
+            old_record: None,
+            changed_columns: vec!["name".to_owned()],
+            commit_lsn: None,
+            commit_timestamp: None,
+        })?;
+
+        assert_eq!(1, jobs.len());
+        assert_eq!(WorkerQueue::ShopOpenSearch, jobs[0].target_queue);
+        assert_eq!(
+            "shop:20000000-0000-0000-0000-000000000001:7:update",
+            jobs[0].idempotency_key.as_str()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_route_search_filter_when_relevant_columns_change()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&CdcChange {
+            schema: Some("public".to_owned()),
+            table: "search_filters".to_owned(),
+            operation: CdcOperation::Update,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({
+                "user_id": "10000000-0000-0000-0000-000000000001",
+                "user_search_filter_id": "50000000-0000-0000-0000-000000000001",
+                "version": 3,
+            })),
+            old_record: None,
+            changed_columns: vec!["search".to_owned()],
+            commit_lsn: None,
+            commit_timestamp: None,
+        })?;
+
+        assert_eq!(1, jobs.len());
+        assert_eq!(WorkerQueue::SearchFilterOpenSearch, jobs[0].target_queue);
+        assert_eq!(
+            "search-filter:50000000-0000-0000-0000-000000000001:3:update",
+            jobs[0].idempotency_key.as_str()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_ignore_search_filter_when_irrelevant_columns_change()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&CdcChange {
+            schema: Some("public".to_owned()),
+            table: "search_filters".to_owned(),
+            operation: CdcOperation::Update,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({
+                "user_id": "10000000-0000-0000-0000-000000000001",
+                "user_search_filter_id": "50000000-0000-0000-0000-000000000001",
+                "version": 3,
+            })),
+            old_record: None,
+            changed_columns: vec!["updated".to_owned()],
+            commit_lsn: None,
+            commit_timestamp: None,
+        })?;
+
+        assert!(jobs.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn should_route_user_tier_change() -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&CdcChange {
+            schema: Some("public".to_owned()),
+            table: "users".to_owned(),
+            operation: CdcOperation::Update,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({
+                "user_id": "10000000-0000-0000-0000-000000000001",
+                "tier": "PREMIUM",
+                "version": 4,
+            })),
+            old_record: Some(serde_json::json!({
+                "user_id": "10000000-0000-0000-0000-000000000001",
+                "tier": "FREE",
+                "version": 3,
+            })),
+            changed_columns: vec!["tier".to_owned()],
+            commit_lsn: None,
+            commit_timestamp: None,
+        })?;
+
+        assert_eq!(1, jobs.len());
+        assert_eq!(WorkerQueue::UserTierEnforcement, jobs[0].target_queue);
+        assert_eq!(
+            "user-tier:10000000-0000-0000-0000-000000000001:4",
+            jobs[0].idempotency_key.as_str()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn should_ignore_unknown_table() -> Result<(), Box<dyn std::error::Error>> {
+        let jobs = route_change(&CdcChange {
+            schema: Some("public".to_owned()),
+            table: "future_table".to_owned(),
+            operation: CdcOperation::Insert,
+            primary_key: BTreeMap::new(),
+            record: Some(serde_json::json!({ "id": "1" })),
+            old_record: None,
+            changed_columns: Vec::new(),
+            commit_lsn: None,
+            commit_timestamp: None,
+        })?;
+
+        assert!(jobs.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_ack_after_all_jobs_are_enqueued() -> Result<(), Box<dyn std::error::Error>> {
+        let (product_sender, mut product_receiver) = in_memory_queue(QueueConfig::new(8))?;
+        let (percolator_sender, mut percolator_receiver) = in_memory_queue(QueueConfig::new(8))?;
+        let (embed_sender, mut embed_receiver) = in_memory_queue(QueueConfig::new(8))?;
+        let registry = WorkerQueueRegistry::new()
+            .with_queue(WorkerQueue::ProductOpenSearch, product_sender)
+            .with_queue(WorkerQueue::SearchFilterPercolator, percolator_sender)
+            .with_queue(WorkerQueue::ProductEmbed, embed_sender);
+        let fanout = CdcFanout::new(registry);
+        let batch = CdcBatch {
+            delivery_id: Some("delivery-1".to_owned()),
+            source: Some("postgres".to_owned()),
+            changes: vec![product_event_change("DOMAIN_CREATED", "DOMAIN")],
+        };
+
+        let enqueued = fanout.ingest_batch(&batch).await?;
+
+        assert_eq!(3, enqueued);
+        assert!(product_receiver.recv().await.is_some());
+        assert!(percolator_receiver.recv().await.is_some());
+        assert!(embed_receiver.recv().await.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_fail_fanout_when_target_queue_is_missing() {
+        let fanout = CdcFanout::new(WorkerQueueRegistry::new());
+        let batch = CdcBatch {
+            delivery_id: Some("delivery-1".to_owned()),
+            source: Some("postgres".to_owned()),
+            changes: vec![product_event_change("DOMAIN_CREATED", "DOMAIN")],
+        };
+
+        let result = fanout.ingest_batch(&batch).await;
+
+        assert!(matches!(
+            result,
+            Err(CdcIngestError::Fanout(CdcFanoutError::MissingQueue(
+                WorkerQueue::ProductOpenSearch
+            )))
+        ));
+    }
+
+    #[test]
+    fn should_parse_sequin_like_json_with_aliases() -> Result<(), Box<dyn std::error::Error>> {
+        let batch: CdcBatch = serde_json::from_str(
+            r#"{
+                "id": "delivery-1",
+                "source": "postgres",
+                "events": [
+                    {
+                        "table_schema": "public",
+                        "relation": "product_events",
+                        "op": "insert",
+                        "keys": { "event_id": "40000000-0000-0000-0000-000000000001" },
+                        "new": {
+                            "event_id": "40000000-0000-0000-0000-000000000001",
+                            "product_id": "30000000-0000-0000-0000-000000000001",
+                            "event_type": "DOMAIN_CREATED",
+                            "event_group": "DOMAIN"
+                        }
+                    }
+                ]
+            }"#,
+        )?;
+
+        assert_eq!(Some("delivery-1".to_owned()), batch.delivery_id);
+        assert_eq!(1, batch.changes.len());
+        assert_eq!(CdcOperation::Insert, batch.changes[0].operation);
+        Ok(())
+    }
+}

--- a/src/aura-historia-worker/src/lib.rs
+++ b/src/aura-historia-worker/src/lib.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, error, info};
 
-use crate::cdc::{CdcFanout, CdcIngestError, WorkerQueueRegistry};
+use crate::cdc::{CdcFanout, CdcIngestError, WorkerQueueReceivers, WorkerQueueRegistry};
 
 pub const WORKER_HEALTH_BIND_ADDR_ENV: &str = "AURA_HISTORIA_WORKER_HEALTH_BIND_ADDR";
 const DEFAULT_WORKER_HEALTH_BIND_ADDR: &str = "0.0.0.0:8081";
@@ -134,11 +134,22 @@ where
 #[derive(Debug, Clone)]
 pub struct WorkerRuntime {
     cdc_fanout: CdcFanout,
+    _default_receivers: Option<Arc<Mutex<WorkerQueueReceivers>>>,
 }
 
 impl WorkerRuntime {
     pub fn new(cdc_fanout: CdcFanout) -> Self {
-        Self { cdc_fanout }
+        Self {
+            cdc_fanout,
+            _default_receivers: None,
+        }
+    }
+
+    pub fn with_all_queues(
+        config: QueueConfig,
+    ) -> Result<(Self, WorkerQueueReceivers), QueueConfigError> {
+        let (registry, receivers) = WorkerQueueRegistry::with_all_queues(config)?;
+        Ok((Self::new(CdcFanout::new(registry)), receivers))
     }
 
     pub fn empty() -> Self {
@@ -152,7 +163,12 @@ impl WorkerRuntime {
 
 impl Default for WorkerRuntime {
     fn default() -> Self {
-        Self::empty()
+        let (runtime, receivers) = Self::with_all_queues(QueueConfig::new(1024))
+            .expect("default queue capacity should be valid");
+        Self {
+            cdc_fanout: runtime.cdc_fanout,
+            _default_receivers: Some(Arc::new(Mutex::new(receivers))),
+        }
     }
 }
 

--- a/src/aura-historia-worker/src/lib.rs
+++ b/src/aura-historia-worker/src/lib.rs
@@ -1,14 +1,21 @@
+pub mod cdc;
+pub mod retry;
+
 use std::future::Future;
 use std::net::{AddrParseError, SocketAddr};
+use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
+use crate::cdc::{CdcFanout, CdcIngestError, WorkerQueueRegistry};
+
 pub const WORKER_HEALTH_BIND_ADDR_ENV: &str = "AURA_HISTORIA_WORKER_HEALTH_BIND_ADDR";
 const DEFAULT_WORKER_HEALTH_BIND_ADDR: &str = "0.0.0.0:8081";
-const REQUEST_BUFFER_BYTES: usize = 8192;
+const REQUEST_BUFFER_BYTES: usize = 65_536;
+pub const SEQUIN_CDC_PATH: &str = "/cdc/sequin";
 
 pub trait WorkerJob: Send + 'static {}
 
@@ -124,23 +131,48 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct WorkerRuntime {
+    cdc_fanout: CdcFanout,
+}
+
+impl WorkerRuntime {
+    pub fn new(cdc_fanout: CdcFanout) -> Self {
+        Self { cdc_fanout }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(CdcFanout::new(WorkerQueueRegistry::new()))
+    }
+
+    pub async fn ingest_cdc_json(&self, body: &str) -> Result<usize, CdcIngestError> {
+        self.cdc_fanout.ingest_json(body).await
+    }
+}
+
+impl Default for WorkerRuntime {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HealthResponse {
+pub struct HttpResponse {
     pub status_code: u16,
     pub body: &'static str,
 }
 
-pub fn route(method: &str, path: &str) -> HealthResponse {
+pub fn route(method: &str, path: &str) -> HttpResponse {
     match (method, path) {
-        ("GET", "/health") => HealthResponse {
+        ("GET", "/health") => HttpResponse {
             status_code: 200,
             body: "ok\n",
         },
-        ("GET", "/ready") => HealthResponse {
+        ("GET", "/ready") => HttpResponse {
             status_code: 200,
             body: "ready\n",
         },
-        _ => HealthResponse {
+        _ => HttpResponse {
             status_code: 404,
             body: "not found\n",
         },
@@ -151,28 +183,52 @@ pub async fn run_until_shutdown<S>(config: WorkerConfig, shutdown: S) -> Result<
 where
     S: Future<Output = ()>,
 {
+    run_until_shutdown_with_runtime(config, WorkerRuntime::default(), shutdown).await
+}
+
+pub async fn run_until_shutdown_with_runtime<S>(
+    config: WorkerConfig,
+    runtime: WorkerRuntime,
+    shutdown: S,
+) -> Result<(), WorkerRunError>
+where
+    S: Future<Output = ()>,
+{
     let listener = TcpListener::bind(config.health_bind_addr())
         .await
         .map_err(WorkerRunError::Bind)?;
-    serve(listener, shutdown).await
+    serve_with_runtime(listener, runtime, shutdown).await
 }
 
 pub async fn serve<S>(listener: TcpListener, shutdown: S) -> Result<(), WorkerRunError>
 where
     S: Future<Output = ()>,
 {
+    serve_with_runtime(listener, WorkerRuntime::default(), shutdown).await
+}
+
+pub async fn serve_with_runtime<S>(
+    listener: TcpListener,
+    runtime: WorkerRuntime,
+    shutdown: S,
+) -> Result<(), WorkerRunError>
+where
+    S: Future<Output = ()>,
+{
     let local_addr = listener.local_addr().map_err(WorkerRunError::LocalAddr)?;
-    info!(bind_addr = %local_addr, "aura-historia-worker health server listening");
+    info!(bind_addr = %local_addr, "aura-historia-worker health and CDC server listening");
     tokio::pin!(shutdown);
+    let runtime = Arc::new(runtime);
 
     loop {
         tokio::select! {
             accept_result = listener.accept() => {
                 let (stream, peer_addr) = accept_result.map_err(WorkerRunError::Accept)?;
-                debug!(%peer_addr, "accepted worker health connection");
+                let runtime = Arc::clone(&runtime);
+                debug!(%peer_addr, "accepted worker connection");
                 tokio::spawn(async move {
-                    if let Err(error) = handle_connection(stream).await {
-                        error!(%error, "worker health connection failed");
+                    if let Err(error) = handle_connection(stream, runtime).await {
+                        error!(%error, "worker connection failed");
                     }
                 });
             }
@@ -184,30 +240,78 @@ where
     }
 }
 
-async fn handle_connection(mut stream: TcpStream) -> Result<(), std::io::Error> {
+async fn handle_connection(
+    mut stream: TcpStream,
+    runtime: Arc<WorkerRuntime>,
+) -> Result<(), std::io::Error> {
     let mut buffer = [0_u8; REQUEST_BUFFER_BYTES];
     let bytes_read = stream.read(&mut buffer).await?;
     let request = String::from_utf8_lossy(&buffer[..bytes_read]);
-    let (method, path) = parse_request_line(&request).unwrap_or(("", ""));
-    let response = route(method, path);
+    let parsed_request = parse_http_request(&request);
+    let response = handle_request(parsed_request, runtime).await;
     write_response(&mut stream, response).await
 }
 
-fn parse_request_line(request: &str) -> Option<(&str, &str)> {
-    let line = request.lines().next()?;
+async fn handle_request(
+    parsed_request: Option<HttpRequest<'_>>,
+    runtime: Arc<WorkerRuntime>,
+) -> HttpResponse {
+    let Some(request) = parsed_request else {
+        return HttpResponse {
+            status_code: 400,
+            body: "bad request\n",
+        };
+    };
+
+    if request.method == "POST" && request.path == SEQUIN_CDC_PATH {
+        return match runtime.ingest_cdc_json(request.body).await {
+            Ok(_) => HttpResponse {
+                status_code: 202,
+                body: "accepted\n",
+            },
+            Err(CdcIngestError::InvalidJson(_)) => HttpResponse {
+                status_code: 400,
+                body: "invalid CDC JSON\n",
+            },
+            Err(error) => {
+                error!(%error, "CDC fanout failed; requesting Sequin retry");
+                HttpResponse {
+                    status_code: 503,
+                    body: "CDC fanout failed\n",
+                }
+            }
+        };
+    }
+
+    route(request.method, request.path)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HttpRequest<'a> {
+    method: &'a str,
+    path: &'a str,
+    body: &'a str,
+}
+
+fn parse_http_request(request: &str) -> Option<HttpRequest<'_>> {
+    let (head, body) = request.split_once("\r\n\r\n").unwrap_or((request, ""));
+    let line = head.lines().next()?;
     let mut parts = line.split_whitespace();
     let method = parts.next()?;
     let path = parts.next()?;
-    Some((method, path))
+    Some(HttpRequest { method, path, body })
 }
 
 async fn write_response(
     stream: &mut TcpStream,
-    response: HealthResponse,
+    response: HttpResponse,
 ) -> Result<(), std::io::Error> {
     let status = match response.status_code {
         200 => "200 OK",
+        202 => "202 Accepted",
+        400 => "400 Bad Request",
         404 => "404 Not Found",
+        503 => "503 Service Unavailable",
         _ => "500 Internal Server Error",
     };
     let bytes = response.body.as_bytes();
@@ -239,6 +343,7 @@ mod tests {
     use std::net::SocketAddr;
 
     use super::*;
+    use crate::cdc::{CdcFanout, DomainJob, WorkerQueue, WorkerQueueRegistry};
     use rstest::rstest;
     use tokio::sync::oneshot;
 
@@ -347,17 +452,93 @@ mod tests {
             let _ = shutdown_rx.await;
         }));
 
-        let mut stream = TcpStream::connect(addr).await?;
-        stream
-            .write_all(b"GET /health HTTP/1.1\r\nhost: localhost\r\n\r\n")
-            .await?;
-        let mut response = String::new();
-        stream.read_to_string(&mut response).await?;
+        let response = request(addr, "GET /health HTTP/1.1\r\nhost: localhost\r\n\r\n").await?;
         let _send_result = shutdown_tx.send(());
         server.await??;
 
         assert!(response.starts_with("HTTP/1.1 200 OK"));
         assert!(response.ends_with("ok\n"));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_accept_sequin_cdc_after_fanout() -> Result<(), Box<dyn std::error::Error>> {
+        let (product_sender, mut product_receiver) =
+            in_memory_queue::<DomainJob>(QueueConfig::new(8))?;
+        let (percolator_sender, mut percolator_receiver) =
+            in_memory_queue::<DomainJob>(QueueConfig::new(8))?;
+        let (embed_sender, mut embed_receiver) = in_memory_queue::<DomainJob>(QueueConfig::new(8))?;
+        let runtime = WorkerRuntime::new(CdcFanout::new(
+            WorkerQueueRegistry::new()
+                .with_queue(WorkerQueue::ProductOpenSearch, product_sender)
+                .with_queue(WorkerQueue::SearchFilterPercolator, percolator_sender)
+                .with_queue(WorkerQueue::ProductEmbed, embed_sender),
+        ));
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(serve_with_runtime(listener, runtime, async move {
+            let _ = shutdown_rx.await;
+        }));
+        let body = r#"{
+            "changes": [
+                {
+                    "table": "product_events",
+                    "operation": "insert",
+                    "record": {
+                        "event_id": "40000000-0000-0000-0000-000000000001",
+                        "product_id": "30000000-0000-0000-0000-000000000001",
+                        "event_type": "DOMAIN_CREATED",
+                        "event_group": "DOMAIN"
+                    }
+                }
+            ]
+        }"#;
+        let request_text = format!(
+            "POST {SEQUIN_CDC_PATH} HTTP/1.1\r\nhost: localhost\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let response = request(addr, &request_text).await?;
+        let _send_result = shutdown_tx.send(());
+        server.await??;
+
+        assert!(response.starts_with("HTTP/1.1 202 Accepted"));
+        assert!(product_receiver.recv().await.is_some());
+        assert!(percolator_receiver.recv().await.is_some());
+        assert!(embed_receiver.recv().await.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_reject_invalid_sequin_cdc_json() -> Result<(), Box<dyn std::error::Error>> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(serve(listener, async move {
+            let _ = shutdown_rx.await;
+        }));
+        let request_text = format!(
+            "POST {SEQUIN_CDC_PATH} HTTP/1.1\r\nhost: localhost\r\ncontent-length: 8\r\n\r\nnot-json"
+        );
+
+        let response = request(addr, &request_text).await?;
+        let _send_result = shutdown_tx.send(());
+        server.await??;
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
+        Ok(())
+    }
+
+    async fn request(
+        addr: SocketAddr,
+        request_text: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let mut stream = TcpStream::connect(addr).await?;
+        stream.write_all(request_text.as_bytes()).await?;
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await?;
+        Ok(response)
     }
 }

--- a/src/aura-historia-worker/src/retry.rs
+++ b/src/aura-historia-worker/src/retry.rs
@@ -1,0 +1,238 @@
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::future::Future;
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tracing::warn;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryConfig {
+    max_attempts: u32,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+}
+
+impl RetryConfig {
+    pub const fn new(max_attempts: u32, initial_backoff: Duration, max_backoff: Duration) -> Self {
+        Self {
+            max_attempts,
+            initial_backoff,
+            max_backoff,
+        }
+    }
+
+    pub const fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    pub const fn initial_backoff(&self) -> Duration {
+        self.initial_backoff
+    }
+
+    pub const fn max_backoff(&self) -> Duration {
+        self.max_backoff
+    }
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self::new(3, Duration::from_millis(100), Duration::from_secs(5))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InMemoryDeadLetterQueue<T> {
+    entries: Arc<Mutex<Vec<DeadLetter<T>>>>,
+}
+
+impl<T> Default for InMemoryDeadLetterQueue<T> {
+    fn default() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl<T> InMemoryDeadLetterQueue<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn push(&self, job: T, reason: String, attempts: u32) {
+        self.entries.lock().await.push(DeadLetter {
+            job,
+            reason,
+            attempts,
+        });
+    }
+
+    pub async fn entries(&self) -> Vec<DeadLetter<T>>
+    where
+        T: Clone,
+    {
+        self.entries.lock().await.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeadLetter<T> {
+    pub job: T,
+    pub reason: String,
+    pub attempts: u32,
+}
+
+pub async fn run_with_retry<T, F, Fut, E>(
+    job: T,
+    config: RetryConfig,
+    dead_letters: &InMemoryDeadLetterQueue<T>,
+    mut handler: F,
+) -> Result<(), RetryError<E>>
+where
+    T: Clone,
+    F: FnMut(T) -> Fut,
+    Fut: Future<Output = Result<(), E>>,
+    E: Display,
+{
+    let max_attempts = config.max_attempts().max(1);
+    let mut attempt = 1;
+    let mut backoff = config.initial_backoff();
+
+    loop {
+        match handler(job.clone()).await {
+            Ok(()) => return Ok(()),
+            Err(error) if attempt >= max_attempts => {
+                let reason = error.to_string();
+                warn!(attempts = attempt, %reason, "job retries exhausted; moving to in-memory DLQ");
+                dead_letters.push(job, reason, attempt).await;
+                return Err(RetryError::Exhausted {
+                    source: error,
+                    attempts: attempt,
+                });
+            }
+            Err(error) => {
+                warn!(attempt, error = %error, "job attempt failed; retrying in process");
+                if !backoff.is_zero() {
+                    tokio::time::sleep(backoff).await;
+                }
+                backoff = next_backoff(backoff, config.max_backoff());
+                attempt += 1;
+            }
+        }
+    }
+}
+
+fn next_backoff(current: Duration, max: Duration) -> Duration {
+    let doubled = current.saturating_mul(2);
+    if doubled > max { max } else { doubled }
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum RetryError<E> {
+    #[error("job retries exhausted after {attempts} attempts")]
+    Exhausted { source: E, attempts: u32 },
+}
+
+#[derive(Debug, Clone)]
+pub struct InProcessIdempotencyStore<K> {
+    processed: Arc<Mutex<HashSet<K>>>,
+}
+
+impl<K> Default for InProcessIdempotencyStore<K> {
+    fn default() -> Self {
+        Self {
+            processed: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl<K> InProcessIdempotencyStore<K>
+where
+    K: Eq + Hash + Clone,
+{
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn is_processed(&self, key: &K) -> bool {
+        self.processed.lock().await.contains(key)
+    }
+
+    pub async fn record_processed(&self, key: K) -> bool {
+        self.processed.lock().await.insert(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn should_retry_until_job_succeeds() -> Result<(), Box<dyn std::error::Error>> {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_handler = attempts.clone();
+        let dead_letters = InMemoryDeadLetterQueue::new();
+        let config = RetryConfig::new(3, Duration::ZERO, Duration::ZERO);
+
+        let result = run_with_retry("job-1".to_owned(), config, &dead_letters, move |_job| {
+            let attempts_for_future = attempts_for_handler.clone();
+            async move {
+                let next_attempt = attempts_for_future.fetch_add(1, Ordering::SeqCst) + 1;
+                if next_attempt < 2 {
+                    Err("transient")
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(2, attempts.load(Ordering::SeqCst));
+        assert!(dead_letters.entries().await.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_move_job_to_in_memory_dlq_when_retries_are_exhausted() {
+        let dead_letters = InMemoryDeadLetterQueue::new();
+        let config = RetryConfig::new(2, Duration::ZERO, Duration::ZERO);
+
+        let result = run_with_retry("job-1".to_owned(), config, &dead_letters, |_job| async {
+            Err::<(), _>("permanent")
+        })
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(RetryError::Exhausted {
+                source: "permanent",
+                attempts: 2,
+            })
+        ));
+        assert_eq!(
+            vec![DeadLetter {
+                job: "job-1".to_owned(),
+                reason: "permanent".to_owned(),
+                attempts: 2,
+            }],
+            dead_letters.entries().await
+        );
+    }
+
+    #[tokio::test]
+    async fn should_track_processed_idempotency_keys() {
+        let store = InProcessIdempotencyStore::new();
+        let key = "product-event:40000000-0000-0000-0000-000000000001".to_owned();
+
+        assert!(!store.is_processed(&key).await);
+        assert!(store.record_processed(key.clone()).await);
+        assert!(store.is_processed(&key).await);
+        assert!(!store.record_processed(key).await);
+    }
+}

--- a/src/test-api/AGENTS.md
+++ b/src/test-api/AGENTS.md
@@ -33,7 +33,7 @@
 - Share helpers before copy-paste fixtures.
 - Prefer `Postgres`/`OperationalBackendPostgres` and `postgres` feature over legacy `Rds`/`rds` in new tests.
 - Use `Postgres::new("migrations")` for the shared business schema.
-- Use `start_sequin(<worker-webhook-url>)` when a test must verify real Sequin webhook delivery to a local worker endpoint.
+- Use `Sequin::worker_webhook()` in `#[aura_integration_test]` plus `get_sequin_worker_webhook_bind_addr()` when a test must verify real Sequin webhook delivery to a local worker endpoint.
 
 ## Verification
 

--- a/src/test-api/AGENTS.md
+++ b/src/test-api/AGENTS.md
@@ -7,7 +7,7 @@
 ## Core Design
 
 - LocalStack and AWS integration test harness.
-- Root modules: `api_gateway`, `cloudformation`, `cognito`, `dynamodb`, `eventbridge`, `localstack`, `opensearch`, `postgres`, `s3`, `ses`, `signal`, `sqs`.
+- Root modules: `api_gateway`, `cloudformation`, `cognito`, `dynamodb`, `eventbridge`, `localstack`, `opensearch`, `postgres`, `s3`, `sequin`, `ses`, `signal`, `sqs`.
 - Child crates: `test-api-macros`.
 - Main neighbors: `aws-tests-common`, `common`, `test-api-macros`, `user`.
 - Test crate. Favor stable helpers and black-box assertions.
@@ -33,6 +33,7 @@
 - Share helpers before copy-paste fixtures.
 - Prefer `Postgres`/`OperationalBackendPostgres` and `postgres` feature over legacy `Rds`/`rds` in new tests.
 - Use `Postgres::new("migrations")` for the shared business schema.
+- Use `start_sequin(<worker-webhook-url>)` when a test must verify real Sequin webhook delivery to a local worker endpoint.
 
 ## Verification
 

--- a/src/test-api/Cargo.toml
+++ b/src/test-api/Cargo.toml
@@ -47,6 +47,7 @@ zip = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 user = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true, features = ["json"] }
+base64 = { workspace = true, optional = true }
 aws-sdk-sesv2 = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -58,9 +59,11 @@ test-api = { workspace = true, features = [
     "postgres",
     "ses",
     "sqs",
-    "cognito"
+    "cognito",
+    "sequin"
 ]}
 rstest = { workspace = true }
+aura-historia-worker = { workspace = true }
 
 [features]
 default = []
@@ -68,8 +71,9 @@ api-gateway = ["aws_lambda_events", "aws_lambda_events/apigw"]
 dynamodb = ["dep:aws-sdk-dynamodb", "serde_dynamo"]
 opensearch = ["dep:opensearch", "dep:aws-sdk-opensearch"]
 postgres = ["dep:sqlx"]
+sequin = ["dep:base64", "dep:reqwest", "postgres"]
 sqs = ["dep:aws-sdk-sqs"]
 eventbridge = ["dep:aws-sdk-eventbridge"]
 cognito = ["dep:aws-sdk-cognitoidentityprovider", "user/full"]
-ses = ["dep:aws-sdk-sesv2", "reqwest"]
+ses = ["dep:aws-sdk-sesv2", "dep:reqwest"]
 cloudformation = ["dep:aws-sdk-cloudformation", "dep:aws-sdk-s3", "dep:aws-tests-common", "dep:zip", "dep:futures", "dep:mrml", "cognito", "dynamodb", "opensearch", "sqs", "ses", "eventbridge"]

--- a/src/test-api/src/lib.rs
+++ b/src/test-api/src/lib.rs
@@ -14,6 +14,8 @@ mod opensearch;
 #[cfg(feature = "postgres")]
 mod postgres;
 mod s3;
+#[cfg(feature = "sequin")]
+mod sequin;
 #[cfg(feature = "ses")]
 mod ses;
 mod signal;
@@ -34,8 +36,10 @@ pub use eventbridge::get_eventbridge_client;
 #[cfg(feature = "opensearch")]
 pub use opensearch::{OpenSearch, get_opensearch_client, read_by_id, refresh_index};
 #[cfg(feature = "postgres")]
-pub use postgres::{Postgres, get_postgres_client};
+pub use postgres::{Postgres, get_postgres_client, get_postgres_host_gateway_connection_string};
 pub use s3::S3;
+#[cfg(feature = "sequin")]
+pub use sequin::*;
 pub use serial_test::serial;
 #[cfg(feature = "ses")]
 pub use ses::*;

--- a/src/test-api/src/postgres.rs
+++ b/src/test-api/src/postgres.rs
@@ -13,6 +13,7 @@ const POSTGRES_PASSWORD: &str = "postgres";
 const POSTGRES_DB: &str = "postgres";
 const POSTGRES_PORT: u16 = 5432;
 const POSTGRES_CONTAINER_NAME: &str = "aura-historia-aws-backend-postgres-test";
+const HOST_GATEWAY: &str = "host.docker.internal";
 
 /// Guards the one-time startup of the Postgres container.
 ///
@@ -21,9 +22,17 @@ const POSTGRES_CONTAINER_NAME: &str = "aura-historia-aws-backend-postgres-test";
 static POSTGRES_CONTAINER_STARTED: OnceCell<()> = OnceCell::const_new();
 
 fn connection_string() -> String {
+    postgres_connection_string("localhost", POSTGRES_DB)
+}
+
+pub fn get_postgres_host_gateway_connection_string(database: &str) -> String {
+    postgres_connection_string(HOST_GATEWAY, database)
+}
+
+fn postgres_connection_string(host: &str, database: &str) -> String {
     format!(
-        "postgres://{}:{}@localhost:{}/{}",
-        POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_PORT, POSTGRES_DB,
+        "postgres://{}:{}@{}:{}/{}",
+        POSTGRES_USER, POSTGRES_PASSWORD, host, POSTGRES_PORT, database,
     )
 }
 
@@ -64,6 +73,8 @@ async fn ensure_container_started() {
                 .with_user(POSTGRES_USER)
                 .with_password(POSTGRES_PASSWORD)
                 .with_db_name(POSTGRES_DB)
+                .with_tag("16-alpine")
+                .with_cmd(["-c", "fsync=off", "-c", "wal_level=logical"])
                 .with_container_name(POSTGRES_CONTAINER_NAME)
                 .with_mapped_port(POSTGRES_PORT, POSTGRES_PORT.tcp())
                 .start()

--- a/src/test-api/src/sequin.rs
+++ b/src/test-api/src/sequin.rs
@@ -6,7 +6,8 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use reqwest::StatusCode;
 use sqlx::Executor;
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpListener};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use testcontainers::core::{Host, IntoContainerPort, WaitFor};
@@ -22,14 +23,32 @@ const SECRET_KEY_BASE: &str = "wDPLYus0pvD6qJhKJICO4dauYPXfO/Yl782Zjtpew5qRBDp7C
 const VAULT_KEY: &str = "2Sig69bIpuSm2kv0VQfDekET2qy8qUZGI8v3/h3ASiY=";
 static SEQUIN_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static DEFAULT_SEQUIN: OnceCell<RunningSequin> = OnceCell::const_new();
+static WORKER_WEBHOOK_SEQUIN: OnceCell<RunningSequin> = OnceCell::const_new();
+static WORKER_WEBHOOK_PORT: OnceLock<u16> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy)]
-pub struct Sequin;
+pub struct Sequin {
+    mode: SequinMode,
+}
 
 impl Sequin {
     pub const fn new() -> Self {
-        Self
+        Self {
+            mode: SequinMode::NoSink,
+        }
     }
+
+    pub const fn worker_webhook() -> Self {
+        Self {
+            mode: SequinMode::WorkerWebhook,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SequinMode {
+    NoSink,
+    WorkerWebhook,
 }
 
 impl Default for Sequin {
@@ -45,7 +64,14 @@ impl IntegrationTestService for Sequin {
     }
 
     async fn set_up(&self) {
-        get_or_start_sequin().await;
+        match self.mode {
+            SequinMode::NoSink => {
+                get_or_start_sequin().await;
+            }
+            SequinMode::WorkerWebhook => {
+                get_or_start_worker_webhook_sequin().await;
+            }
+        }
     }
 }
 
@@ -74,12 +100,22 @@ impl RunningSequin {
 
 pub async fn get_or_start_sequin() -> &'static RunningSequin {
     DEFAULT_SEQUIN
-        .get_or_init(|| async { start_sequin_without_sink().await })
+        .get_or_init(|| async { start_sequin_container(None).await })
         .await
 }
 
-async fn start_sequin_without_sink() -> RunningSequin {
-    start_sequin_container(None).await
+pub async fn get_or_start_worker_webhook_sequin() -> &'static RunningSequin {
+    WORKER_WEBHOOK_SEQUIN
+        .get_or_init(|| async {
+            let port = worker_webhook_port();
+            let webhook_url = format!("http://host.docker.internal:{port}/cdc/sequin");
+            start_sequin_container(Some(&webhook_url)).await
+        })
+        .await
+}
+
+pub fn get_sequin_worker_webhook_bind_addr() -> SocketAddr {
+    SocketAddr::from(([0, 0, 0, 0], worker_webhook_port()))
 }
 
 pub async fn start_sequin(webhook_url: &str) -> RunningSequin {
@@ -156,72 +192,26 @@ fn find_free_port() -> u16 {
         .port()
 }
 
+fn worker_webhook_port() -> u16 {
+    *WORKER_WEBHOOK_PORT.get_or_init(find_free_port)
+}
+
 fn sequin_resource_suffix() -> String {
     let sequence = SEQUIN_SEQUENCE.fetch_add(1, Ordering::SeqCst);
     format!("{}_{}", std::process::id(), sequence)
 }
 
 fn sequin_config_yaml(webhook_url: Option<&str>, suffix: &str) -> String {
-    let sink_yaml = webhook_url
-        .map(|url| {
-            format!(
-                r#"
-http_endpoints:
-  - name: "worker"
-    url: "{url}"
+    let mut config = include_str!("sequin/base.yaml").replace("__SUFFIX__", suffix);
 
-sinks:
-  - name: "worker-product-events"
-    database: "aura-historia-business-{suffix}"
-    source:
-      include_tables:
-        - "public.product_events"
-    actions:
-      - insert
-    batch_size: 1
-    destination:
-      type: "webhook"
-      http_endpoint: "worker"
-      batch: false
-"#,
-            )
-        })
-        .unwrap_or_default();
+    if let Some(url) = webhook_url {
+        let sink_yaml = include_str!("sequin/webhook-sink.yaml")
+            .replace("__SUFFIX__", suffix)
+            .replace("__WEBHOOK_URL__", url);
+        config.push_str(&sink_yaml);
+    }
 
-    format!(
-        r#"account:
-  name: "aura-historia-test"
-
-users:
-  - email: "admin@example.com"
-    password: "sequinpassword!"
-
-api_tokens:
-  - name: "test"
-    token: "test-token"
-
-databases:
-  - name: "aura-historia-business-{suffix}"
-    username: "postgres"
-    password: "postgres"
-    hostname: "host.docker.internal"
-    port: 5432
-    database: "postgres"
-    pool_size: 3
-    slot:
-      name: "aura_historia_test_slot_{suffix}"
-      create_if_not_exists: true
-    publication:
-      name: "aura_historia_test_pub_{suffix}"
-      create_if_not_exists: true
-      init_sql: |-
-        create publication aura_historia_test_pub_{suffix} for table public.product_events with (publish_via_partition_root = true)
-    await_database:
-      timeout_ms: 30000
-      interval_ms: 1000
-
-{sink_yaml}"#,
-    )
+    config
 }
 
 async fn wait_for_sequin_health(endpoint_url: &str, container: &ContainerAsync<GenericImage>) {

--- a/src/test-api/src/sequin.rs
+++ b/src/test-api/src/sequin.rs
@@ -1,0 +1,247 @@
+use crate::{
+    IntegrationTestService, get_postgres_client, get_postgres_host_gateway_connection_string,
+};
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use reqwest::StatusCode;
+use sqlx::Executor;
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use testcontainers::core::{Host, IntoContainerPort, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+use tokio::sync::OnceCell;
+use tracing::debug;
+
+const REDIS_CONTAINER_PORT: u16 = 6379;
+const SEQUIN_CONTAINER_PORT: u16 = 7376;
+const SEQUIN_STATE_DB: &str = "sequin";
+const SECRET_KEY_BASE: &str = "wDPLYus0pvD6qJhKJICO4dauYPXfO/Yl782Zjtpew5qRBDp7CZvbWtQmY0eB13If";
+const VAULT_KEY: &str = "2Sig69bIpuSm2kv0VQfDekET2qy8qUZGI8v3/h3ASiY=";
+static SEQUIN_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static DEFAULT_SEQUIN: OnceCell<RunningSequin> = OnceCell::const_new();
+
+#[derive(Debug, Clone, Copy)]
+pub struct Sequin;
+
+impl Sequin {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for Sequin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl IntegrationTestService for Sequin {
+    fn service_names(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    async fn set_up(&self) {
+        get_or_start_sequin().await;
+    }
+}
+
+#[derive(Debug)]
+pub struct RunningSequin {
+    endpoint_url: String,
+    _redis: ContainerAsync<GenericImage>,
+    _sequin: ContainerAsync<GenericImage>,
+}
+
+impl RunningSequin {
+    pub fn endpoint_url(&self) -> &str {
+        &self.endpoint_url
+    }
+
+    pub async fn stdout_string(&self) -> String {
+        String::from_utf8_lossy(&self._sequin.stdout_to_vec().await.unwrap_or_default())
+            .into_owned()
+    }
+
+    pub async fn stderr_string(&self) -> String {
+        String::from_utf8_lossy(&self._sequin.stderr_to_vec().await.unwrap_or_default())
+            .into_owned()
+    }
+}
+
+pub async fn get_or_start_sequin() -> &'static RunningSequin {
+    DEFAULT_SEQUIN
+        .get_or_init(|| async { start_sequin_without_sink().await })
+        .await
+}
+
+async fn start_sequin_without_sink() -> RunningSequin {
+    start_sequin_container(None).await
+}
+
+pub async fn start_sequin(webhook_url: &str) -> RunningSequin {
+    start_sequin_container(Some(webhook_url)).await
+}
+
+async fn start_sequin_container(webhook_url: Option<&str>) -> RunningSequin {
+    ensure_sequin_state_database().await;
+
+    let suffix = sequin_resource_suffix();
+    let redis_port = find_free_port();
+    let redis = GenericImage::new("redis", "7-alpine")
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .with_mapped_port(redis_port, REDIS_CONTAINER_PORT.tcp())
+        .start()
+        .await
+        .expect("shouldn't fail starting Redis test container for Sequin");
+
+    let config_yaml = sequin_config_yaml(webhook_url, &suffix);
+    let config_yaml_base64 = STANDARD.encode(config_yaml);
+    let redis_url = format!("redis://host.docker.internal:{redis_port}");
+    let sequin_state_pg_url = get_postgres_host_gateway_connection_string(SEQUIN_STATE_DB);
+
+    let sequin_port = find_free_port();
+    let sequin = GenericImage::new("sequin/sequin", "latest")
+        .with_wait_for(WaitFor::seconds(5))
+        .with_env_var("SERVER_PORT", SEQUIN_CONTAINER_PORT.to_string())
+        .with_env_var("PG_URL", sequin_state_pg_url)
+        .with_env_var("PG_POOL_SIZE", "3")
+        .with_env_var("REDIS_URL", redis_url)
+        .with_env_var("SECRET_KEY_BASE", SECRET_KEY_BASE)
+        .with_env_var("VAULT_KEY", VAULT_KEY)
+        .with_env_var("CONFIG_FILE_YAML", config_yaml_base64)
+        .with_env_var("TELEMETRY_ENABLED", "false")
+        .with_env_var("CRASH_REPORTING_DISABLED", "true")
+        .with_host("host.docker.internal", Host::HostGateway)
+        .with_mapped_port(sequin_port, SEQUIN_CONTAINER_PORT.tcp())
+        .start()
+        .await
+        .expect("shouldn't fail starting Sequin test container");
+    let endpoint_url = format!("http://localhost:{sequin_port}");
+
+    wait_for_sequin_health(&endpoint_url, &sequin).await;
+    debug!(%endpoint_url, "Successfully started Sequin test container.");
+
+    RunningSequin {
+        endpoint_url,
+        _redis: redis,
+        _sequin: sequin,
+    }
+}
+
+async fn ensure_sequin_state_database() {
+    let pool = get_postgres_client().await;
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)")
+            .bind(SEQUIN_STATE_DB)
+            .fetch_one(&pool)
+            .await
+            .expect("shouldn't fail checking Sequin state database");
+
+    if !exists {
+        pool.execute(sqlx::raw_sql(&format!("CREATE DATABASE {SEQUIN_STATE_DB}")))
+            .await
+            .expect("shouldn't fail creating Sequin state database");
+    }
+}
+
+fn find_free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("shouldn't fail binding to a random port")
+        .local_addr()
+        .expect("shouldn't fail reading local address")
+        .port()
+}
+
+fn sequin_resource_suffix() -> String {
+    let sequence = SEQUIN_SEQUENCE.fetch_add(1, Ordering::SeqCst);
+    format!("{}_{}", std::process::id(), sequence)
+}
+
+fn sequin_config_yaml(webhook_url: Option<&str>, suffix: &str) -> String {
+    let sink_yaml = webhook_url
+        .map(|url| {
+            format!(
+                r#"
+http_endpoints:
+  - name: "worker"
+    url: "{url}"
+
+sinks:
+  - name: "worker-product-events"
+    database: "aura-historia-business-{suffix}"
+    source:
+      include_tables:
+        - "public.product_events"
+    actions:
+      - insert
+    batch_size: 1
+    destination:
+      type: "webhook"
+      http_endpoint: "worker"
+      batch: false
+"#,
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        r#"account:
+  name: "aura-historia-test"
+
+users:
+  - email: "admin@example.com"
+    password: "sequinpassword!"
+
+api_tokens:
+  - name: "test"
+    token: "test-token"
+
+databases:
+  - name: "aura-historia-business-{suffix}"
+    username: "postgres"
+    password: "postgres"
+    hostname: "host.docker.internal"
+    port: 5432
+    database: "postgres"
+    pool_size: 3
+    slot:
+      name: "aura_historia_test_slot_{suffix}"
+      create_if_not_exists: true
+    publication:
+      name: "aura_historia_test_pub_{suffix}"
+      create_if_not_exists: true
+      init_sql: |-
+        create publication aura_historia_test_pub_{suffix} for table public.product_events with (publish_via_partition_root = true)
+    await_database:
+      timeout_ms: 30000
+      interval_ms: 1000
+
+{sink_yaml}"#,
+    )
+}
+
+async fn wait_for_sequin_health(endpoint_url: &str, container: &ContainerAsync<GenericImage>) {
+    let client = reqwest::Client::new();
+    let health_url = format!("{endpoint_url}/health");
+
+    for _ in 0..30 {
+        if let Ok(response) = client.get(&health_url).send().await
+            && response.status() == StatusCode::OK
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let stdout = container.stdout_to_vec().await.unwrap_or_default();
+    let stderr = container.stderr_to_vec().await.unwrap_or_default();
+    panic!(
+        "Sequin health endpoint did not become ready at {health_url}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+}

--- a/src/test-api/src/sequin/base.yaml
+++ b/src/test-api/src/sequin/base.yaml
@@ -1,0 +1,30 @@
+account:
+  name: "aura-historia-test"
+
+users:
+  - email: "admin@example.com"
+    password: "sequinpassword!"
+
+api_tokens:
+  - name: "test"
+    token: "test-token"
+
+databases:
+  - name: "aura-historia-business-__SUFFIX__"
+    username: "postgres"
+    password: "postgres"
+    hostname: "host.docker.internal"
+    port: 5432
+    database: "postgres"
+    pool_size: 3
+    slot:
+      name: "aura_historia_test_slot___SUFFIX__"
+      create_if_not_exists: true
+    publication:
+      name: "aura_historia_test_pub___SUFFIX__"
+      create_if_not_exists: true
+      init_sql: |-
+        create publication aura_historia_test_pub___SUFFIX__ for table public.product_events with (publish_via_partition_root = true)
+    await_database:
+      timeout_ms: 30000
+      interval_ms: 1000

--- a/src/test-api/src/sequin/webhook-sink.yaml
+++ b/src/test-api/src/sequin/webhook-sink.yaml
@@ -1,0 +1,18 @@
+
+http_endpoints:
+  - name: "worker"
+    url: "__WEBHOOK_URL__"
+
+sinks:
+  - name: "worker-product-events"
+    database: "aura-historia-business-__SUFFIX__"
+    source:
+      include_tables:
+        - "public.product_events"
+    actions:
+      - insert
+    batch_size: 1
+    destination:
+      type: "webhook"
+      http_endpoint: "worker"
+      batch: false

--- a/src/test-api/tests/sequin.rs
+++ b/src/test-api/tests/sequin.rs
@@ -1,0 +1,75 @@
+use std::time::Duration;
+
+use aura_historia_worker::cdc::{CdcFanout, DomainJob, WorkerQueue, WorkerQueueRegistry};
+use aura_historia_worker::{QueueConfig, SEQUIN_CDC_PATH, WorkerRuntime, in_memory_queue};
+use sqlx::Executor;
+use test_api::*;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+const BUSINESS_SCHEMA: Postgres = Postgres::new("migrations");
+
+#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+async fn should_deliver_product_event_change_to_worker_queues() {
+    let (product_sender, mut product_receiver) =
+        in_memory_queue::<DomainJob>(QueueConfig::new(8)).unwrap();
+    let (percolator_sender, mut percolator_receiver) =
+        in_memory_queue::<DomainJob>(QueueConfig::new(8)).unwrap();
+    let runtime = WorkerRuntime::new(CdcFanout::new(
+        WorkerQueueRegistry::new()
+            .with_queue(WorkerQueue::ProductOpenSearch, product_sender)
+            .with_queue(WorkerQueue::SearchFilterPercolator, percolator_sender),
+    ));
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let worker_addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let server = tokio::spawn(aura_historia_worker::serve_with_runtime(
+        listener,
+        runtime,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
+    let worker_webhook_url = format!(
+        "http://host.docker.internal:{}{SEQUIN_CDC_PATH}",
+        worker_addr.port()
+    );
+    let sequin = start_sequin(&worker_webhook_url).await;
+
+    let pool = get_postgres_client().await;
+    let fixture = include_str!("fixtures/business_schema_relations.sql");
+    pool.execute(sqlx::raw_sql(fixture)).await.unwrap();
+
+    let product_job =
+        match tokio::time::timeout(Duration::from_secs(60), product_receiver.recv()).await {
+            Ok(job) => job,
+            Err(error) => {
+                panic!(
+                    "timed out waiting for Sequin product job: {error}\nstdout:\n{}\nstderr:\n{}",
+                    sequin.stdout_string().await,
+                    sequin.stderr_string().await
+                )
+            }
+        };
+    let percolator_job = match tokio::time::timeout(
+        Duration::from_secs(60),
+        percolator_receiver.recv(),
+    )
+    .await
+    {
+        Ok(job) => job,
+        Err(error) => {
+            panic!(
+                "timed out waiting for Sequin percolator job: {error}\nstdout:\n{}\nstderr:\n{}",
+                sequin.stdout_string().await,
+                sequin.stderr_string().await
+            )
+        }
+    };
+
+    let _send_result = shutdown_tx.send(());
+    server.await.unwrap().unwrap();
+
+    assert!(product_job.is_some());
+    assert!(percolator_job.is_some());
+}

--- a/src/test-api/tests/sequin.rs
+++ b/src/test-api/tests/sequin.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use aura_historia_worker::cdc::{CdcFanout, DomainJob, WorkerQueue, WorkerQueueRegistry};
-use aura_historia_worker::{QueueConfig, SEQUIN_CDC_PATH, WorkerRuntime, in_memory_queue};
+use aura_historia_worker::{QueueConfig, WorkerRuntime, in_memory_queue};
 use sqlx::Executor;
 use test_api::*;
 use tokio::net::TcpListener;
@@ -9,7 +9,7 @@ use tokio::sync::oneshot;
 
 const BUSINESS_SCHEMA: Postgres = Postgres::new("migrations");
 
-#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+#[aura_integration_test(services = [BUSINESS_SCHEMA, Sequin::worker_webhook()])]
 async fn should_deliver_product_event_change_to_worker_queues() {
     let (product_sender, mut product_receiver) =
         in_memory_queue::<DomainJob>(QueueConfig::new(8)).unwrap();
@@ -20,8 +20,9 @@ async fn should_deliver_product_event_change_to_worker_queues() {
             .with_queue(WorkerQueue::ProductOpenSearch, product_sender)
             .with_queue(WorkerQueue::SearchFilterPercolator, percolator_sender),
     ));
-    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
-    let worker_addr = listener.local_addr().unwrap();
+    let listener = TcpListener::bind(get_sequin_worker_webhook_bind_addr())
+        .await
+        .unwrap();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let server = tokio::spawn(aura_historia_worker::serve_with_runtime(
         listener,
@@ -30,11 +31,7 @@ async fn should_deliver_product_event_change_to_worker_queues() {
             let _ = shutdown_rx.await;
         },
     ));
-    let worker_webhook_url = format!(
-        "http://host.docker.internal:{}{SEQUIN_CDC_PATH}",
-        worker_addr.port()
-    );
-    let sequin = start_sequin(&worker_webhook_url).await;
+    let sequin = get_or_start_worker_webhook_sequin().await;
 
     let pool = get_postgres_client().await;
     let fixture = include_str!("fixtures/business_schema_relations.sql");

--- a/src/test-api/tests/sequin.rs
+++ b/src/test-api/tests/sequin.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use aura_historia_worker::cdc::{CdcFanout, DomainJob, WorkerQueue, WorkerQueueRegistry};
-use aura_historia_worker::{QueueConfig, WorkerRuntime, in_memory_queue};
+use aura_historia_worker::cdc::WorkerQueue;
+use aura_historia_worker::{QueueConfig, WorkerRuntime};
 use sqlx::Executor;
 use test_api::*;
 use tokio::net::TcpListener;
@@ -11,15 +11,7 @@ const BUSINESS_SCHEMA: Postgres = Postgres::new("migrations");
 
 #[aura_integration_test(services = [BUSINESS_SCHEMA, Sequin::worker_webhook()])]
 async fn should_deliver_product_event_change_to_worker_queues() {
-    let (product_sender, mut product_receiver) =
-        in_memory_queue::<DomainJob>(QueueConfig::new(8)).unwrap();
-    let (percolator_sender, mut percolator_receiver) =
-        in_memory_queue::<DomainJob>(QueueConfig::new(8)).unwrap();
-    let runtime = WorkerRuntime::new(CdcFanout::new(
-        WorkerQueueRegistry::new()
-            .with_queue(WorkerQueue::ProductOpenSearch, product_sender)
-            .with_queue(WorkerQueue::SearchFilterPercolator, percolator_sender),
-    ));
+    let (runtime, mut receivers) = WorkerRuntime::with_all_queues(QueueConfig::new(8)).unwrap();
     let listener = TcpListener::bind(get_sequin_worker_webhook_bind_addr())
         .await
         .unwrap();
@@ -38,35 +30,30 @@ async fn should_deliver_product_event_change_to_worker_queues() {
     pool.execute(sqlx::raw_sql(fixture)).await.unwrap();
 
     let product_job =
-        match tokio::time::timeout(Duration::from_secs(60), product_receiver.recv()).await {
-            Ok(job) => job,
-            Err(error) => {
-                panic!(
-                    "timed out waiting for Sequin product job: {error}\nstdout:\n{}\nstderr:\n{}",
-                    sequin.stdout_string().await,
-                    sequin.stderr_string().await
-                )
-            }
-        };
-    let percolator_job = match tokio::time::timeout(
-        Duration::from_secs(60),
-        percolator_receiver.recv(),
-    )
-    .await
-    {
-        Ok(job) => job,
-        Err(error) => {
-            panic!(
-                "timed out waiting for Sequin percolator job: {error}\nstdout:\n{}\nstderr:\n{}",
-                sequin.stdout_string().await,
-                sequin.stderr_string().await
-            )
-        }
-    };
+        recv_or_dump_sequin_logs(&mut receivers, WorkerQueue::ProductOpenSearch, sequin).await;
+    let percolator_job =
+        recv_or_dump_sequin_logs(&mut receivers, WorkerQueue::SearchFilterPercolator, sequin).await;
 
     let _send_result = shutdown_tx.send(());
     server.await.unwrap().unwrap();
 
     assert!(product_job.is_some());
     assert!(percolator_job.is_some());
+}
+
+async fn recv_or_dump_sequin_logs(
+    receivers: &mut aura_historia_worker::cdc::WorkerQueueReceivers,
+    queue: WorkerQueue,
+    sequin: &RunningSequin,
+) -> Option<aura_historia_worker::cdc::DomainJob> {
+    match receivers.recv_timeout(queue, Duration::from_secs(60)).await {
+        Ok(job) => job,
+        Err(error) => {
+            panic!(
+                "timed out waiting for Sequin job on {queue:?}: {error}\nstdout:\n{}\nstderr:\n{}",
+                sequin.stdout_string().await,
+                sequin.stderr_string().await
+            )
+        }
+    }
 }


### PR DESCRIPTION
Closes #1374
Closes #1375
Parent: #1341

## Intent

Add the first worker-side CDC contract for the Hetzner migration: Sequin delivery enters the worker, gets normalized, routes to domain jobs, and only acks after fanout to bounded in-memory queues succeeds.

## Summary

- Add `POST /cdc/sequin` to `aura-historia-worker`.
- Add Sequin-like CDC batch/change DTOs with aliases for common envelope names.
- Add CDC routing from core Postgres tables to domain jobs and target queues.
- Add domain-first idempotency and ordering keys.
- Add in-process retry, idempotency memory, and in-memory DLQ helpers.
- Update event-flow docs and worker DOX.

## Breaking changes

- None. This extends the new worker crate only.

## Behavior impact

- Worker returns `202 Accepted` only after all derived jobs are enqueued.
- Worker returns `400` for invalid CDC JSON.
- Worker returns `503` when fanout fails, so Sequin can retry.
- No worker tables are added. In-memory queued/retry/DLQ jobs can be lost after process death; MVP accepts this.

## Risk

- The Sequin envelope is intentionally tolerant but may need field-name tuning once real Sequin webhook payloads are configured.
- Queue fanout can duplicate jobs on Sequin retry after partial enqueue; downstream workers must use the domain idempotency keys.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p aura-historia-worker`
- `cargo test -p aura-historia-worker --all-features`
- `cargo clippy -p aura-historia-worker --all-targets --all-features -- -D warnings`
