### PR TITLE
task(1378,1379): add product Postgres service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,6 +5491,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shop",
+ "sqlx",
  "strum 0.28.0",
  "strum_macros 0.28.0",
  "test-api",

--- a/src/product/AGENTS.md
+++ b/src/product/AGENTS.md
@@ -7,7 +7,7 @@
 ## Core Design
 
 - Product domain, repositories, and core product services.
-- Root modules: `core`, `data`, `dynamodb`, `opensearch`, `service`.
+- Root modules: `core`, `data`, `dynamodb`, `opensearch`, `postgres`, `service`.
 
 - Main neighbors: `common`, `fxrate`, `geo`, `shop`.
 - Library crate. Keep domain, persistence, and service seams explicit.
@@ -28,8 +28,11 @@
 ## Work Guidance
 
 - Think caveman. Talk caveman. Few word.
-- Service and repository split stay clean.
+- Exactly one repository per data source: DynamoDB, OpenSearch, Postgres.
+- Product service facade hides source/storage choice from callers and uses domain types.
 - Keep transport and runtime glue out of domain core.
+- Postgres module owns SQL for products and product-events. Persist product row and product-events in one transaction.
+- Postgres must not map through DynamoDB records.
 
 ## Verification
 

--- a/src/product/Cargo.toml
+++ b/src/product/Cargo.toml
@@ -34,12 +34,13 @@ itertools = { workspace = true, optional = true }
 strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
+sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]
 aws-config = { workspace = true }
 fxrate = { workspace = true }
 product = { workspace = true, features = ["full"] }
-test-api = { workspace = true, features = ["dynamodb", "opensearch", "sqs"] }
+test-api = { workspace = true, features = ["dynamodb", "opensearch", "postgres", "sqs"] }
 serial_test = { workspace = true }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
@@ -52,4 +53,5 @@ opensearch = ["dynamodb", "dep:opensearch", "strum", "strum_macros", "common/ope
 sqs = ["aws-sdk-sqs", "common/sqs"]
 service = ["itertools", "shop/dynamodb", "shop/seller", "tokio", "tokio/time", "tokio/sync", "dep:fxrate"]
 test-data = ["fake", "common/test-data", "shop/test-data", "geo/test-data"]
-full = ["data", "dynamodb", "opensearch", "service", "sqs", "test-data"]
+postgres = ["dep:sqlx"]
+full = ["data", "dynamodb", "opensearch", "postgres", "service", "sqs", "test-data"]

--- a/src/product/src/lib.rs
+++ b/src/product/src/lib.rs
@@ -9,5 +9,8 @@ pub mod dynamodb;
 #[cfg(feature = "opensearch")]
 pub mod opensearch;
 
+#[cfg(feature = "postgres")]
+pub mod postgres;
+
 #[cfg(feature = "service")]
 pub mod service;

--- a/src/product/src/postgres/mod.rs
+++ b/src/product/src/postgres/mod.rs
@@ -1,0 +1,5 @@
+pub mod product_event_row;
+pub mod repository;
+
+pub use product_event_row::{ProductEventGroup, ProductEventRow};
+pub use repository::{ProductPostgresRepository, ProductPostgresRepositoryError};

--- a/src/product/src/postgres/product_event_row.rs
+++ b/src/product/src/postgres/product_event_row.rs
@@ -1,0 +1,390 @@
+use crate::core::product_event::domain::{
+    ProductCreatedDomainEventPayload, ProductDomainEventPayload,
+    ProductEstimatePriceChangeDomainEventPayload, ProductImagesChangeDomainEventPayload,
+    ProductPriceChangeDomainEventPayload,
+};
+use crate::core::product_event::{ProductEvent, ProductEventPayload};
+use crate::core::product_image::ProductImage;
+use common::actor::domain::Actor;
+use common::currency::domain::Currency;
+use common::event_id::EventId;
+use common::localized::Localized;
+use common::price::domain::{MonetaryAmount, Price};
+use common::product_id::{ProductId, ProductKey};
+use common::shop_id::ShopId;
+use common::shops_product_id::ShopsProductId;
+use geo::core::address::{GeoAddress, StructuredAddress};
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProductEventGroup {
+    Domain,
+    Enrichment,
+    Policy,
+    Lifecycle,
+}
+
+impl ProductEventGroup {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Domain => "DOMAIN",
+            Self::Enrichment => "ENRICHMENT",
+            Self::Policy => "POLICY",
+            Self::Lifecycle => "LIFECYCLE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProductEventRow {
+    pub event_id: EventId,
+    pub product_id: ProductId,
+    pub shop_id: ShopId,
+    pub shops_product_id: ShopsProductId,
+    pub event_type: String,
+    pub event_group: ProductEventGroup,
+    pub event_type_schema_version: i32,
+    pub payload: Value,
+    pub event_time: OffsetDateTime,
+    pub created_by: Actor,
+}
+
+impl ProductEventRow {
+    pub fn from_event(event: ProductEvent) -> Self {
+        let key = event.payload.key();
+        let event_type = event.payload.event_type().to_owned();
+        let event_group = event_group(&event.payload);
+        let payload = payload_json(&event.payload);
+
+        Self {
+            event_id: event.event_id,
+            product_id: event.aggregate_id,
+            shop_id: key.shop_id,
+            shops_product_id: key.shops_product_id,
+            event_type,
+            event_group,
+            event_type_schema_version: 1,
+            payload,
+            event_time: event.timestamp,
+            created_by: Actor::System,
+        }
+    }
+}
+
+impl From<ProductEvent> for ProductEventRow {
+    fn from(event: ProductEvent) -> Self {
+        Self::from_event(event)
+    }
+}
+
+fn event_group(payload: &ProductEventPayload) -> ProductEventGroup {
+    match payload {
+        ProductEventPayload::ProductDomainEvent(_) => ProductEventGroup::Domain,
+        ProductEventPayload::ProductEnrichmentEvent(_) => ProductEventGroup::Enrichment,
+        ProductEventPayload::ProductPolicyEvent(_) => ProductEventGroup::Policy,
+        ProductEventPayload::ProductLifecycleEvent(_) => ProductEventGroup::Lifecycle,
+    }
+}
+
+fn payload_json(payload: &ProductEventPayload) -> Value {
+    match payload {
+        ProductEventPayload::ProductDomainEvent(payload) => domain_payload_json(payload),
+        ProductEventPayload::ProductEnrichmentEvent(payload) => match payload {
+            crate::core::product_event::enrichment::ProductEnrichmentEventPayload::TranslatedTitle(payload) => json!({
+                "shop_id": payload.shop_id.to_string(),
+                "seller_id": payload.seller_id.to_string(),
+                "shops_product_id": payload.shops_product_id.to_string(),
+                "source_language": payload.source_language.as_str(),
+                "target_language": payload.target_language.as_str(),
+                "target": payload.target.as_ref(),
+            }),
+            crate::core::product_event::enrichment::ProductEnrichmentEventPayload::Embedded(payload) => json!({
+                "shop_id": payload.shop_id.to_string(),
+                "seller_id": payload.seller_id.to_string(),
+                "shops_product_id": payload.shops_product_id.to_string(),
+                "embedding": payload.embedding,
+                "native_title": payload.native_title.as_ref().map(localized_title_json),
+            }),
+        },
+        ProductEventPayload::ProductLifecycleEvent(payload) => match payload {
+            crate::core::product_event::lifecycle::ProductLifecycleEventPayload::Deleted(payload) => json!({
+                "shop_id": payload.shop_id.to_string(),
+                "seller_id": payload.seller_id.to_string(),
+                "shops_product_id": payload.shops_product_id.to_string(),
+                "old_lifecycle": product_lifecycle_str(payload.old_lifecycle),
+                "new_lifecycle": product_lifecycle_str(payload.new_lifecycle),
+            }),
+        },
+        ProductEventPayload::ProductPolicyEvent(payload) => match payload {
+            crate::core::product_event::policy::ProductPolicyEventPayload::ProhibitedContentDecision(payload) => json!({
+                "shop_id": payload.shop_id.to_string(),
+                "seller_id": payload.seller_id.to_string(),
+                "shops_product_id": payload.shops_product_id.to_string(),
+                "decision": payload.decision.as_str(),
+                "reason": payload.reason.as_str(),
+            }),
+        },
+    }
+}
+
+fn domain_payload_json(payload: &ProductDomainEventPayload) -> Value {
+    match payload {
+        ProductDomainEventPayload::Created(payload) => created_payload_json(payload),
+        ProductDomainEventPayload::StateChanged(payload) => json!({
+            "shop_id": payload.shop_id.to_string(),
+            "seller_id": payload.seller_id.to_string(),
+            "shops_product_id": payload.shops_product_id.to_string(),
+            "old_state": product_state_str(payload.old_state),
+            "new_state": product_state_str(payload.new_state),
+        }),
+        ProductDomainEventPayload::PriceChanged(payload) => price_changed_payload_json(payload),
+        ProductDomainEventPayload::EstimatePriceChanged(payload) => {
+            estimate_price_changed_payload_json(payload)
+        }
+        ProductDomainEventPayload::UrlChanged(payload) => json!({
+            "shop_id": payload.shop_id.to_string(),
+            "seller_id": payload.seller_id.to_string(),
+            "shops_product_id": payload.shops_product_id.to_string(),
+            "url": payload.url.as_str(),
+            "view_url": payload.view_url.as_str(),
+        }),
+        ProductDomainEventPayload::ImagesChanged(payload) => images_changed_payload_json(payload),
+        ProductDomainEventPayload::AuctionTimeChanged(payload) => json!({
+            "shop_id": payload.shop_id.to_string(),
+            "seller_id": payload.seller_id.to_string(),
+            "shops_product_id": payload.shops_product_id.to_string(),
+            "auction_start": payload.auction_start,
+            "auction_end": payload.auction_end,
+        }),
+    }
+}
+
+fn created_payload_json(payload: &ProductCreatedDomainEventPayload) -> Value {
+    json!({
+        "product_slug_id": payload.product_slug_id.to_string(),
+        "shop_slug_id": payload.shop_slug_id.to_string(),
+        "seller_slug_id": payload.seller_slug_id.to_string(),
+        "shop_id": payload.shop_id.to_string(),
+        "seller_id": payload.seller_id.to_string(),
+        "shops_product_id": payload.shops_product_id.to_string(),
+        "shop_name": payload.shop_name.to_string(),
+        "seller_name": payload.seller_name.to_string(),
+        "shop_type": shop_type_str(payload.shop_type),
+        "structured_address": payload.structured_address.as_ref().map(structured_address_json),
+        "geo_address": payload.geo_address.as_ref().map(geo_address_json),
+        "native_title": localized_title_json(&payload.native_title),
+        "native_description": payload.native_description.as_ref().map(localized_description_json),
+        "native_price": payload.native_price.as_ref().map(price_json),
+        "other_price": money_map_json(&payload.other_price),
+        "native_price_estimate_min": payload.native_price_estimate_min.as_ref().map(price_json),
+        "other_price_estimate_min": money_map_json(&payload.other_price_estimate_min),
+        "native_price_estimate_max": payload.native_price_estimate_max.as_ref().map(price_json),
+        "other_price_estimate_max": money_map_json(&payload.other_price_estimate_max),
+        "state": product_state_str(payload.state),
+        "url": payload.url.as_str(),
+        "view_url": payload.view_url.as_str(),
+        "images": images_json(&payload.images),
+        "auction_start": payload.auction_start,
+        "auction_end": payload.auction_end,
+    })
+}
+
+fn price_changed_payload_json(payload: &ProductPriceChangeDomainEventPayload) -> Value {
+    json!({
+        "shop_id": payload.shop_id.to_string(),
+        "seller_id": payload.seller_id.to_string(),
+        "shops_product_id": payload.shops_product_id.to_string(),
+        "old_native_price": payload.old_native_price.as_ref().map(price_json),
+        "old_other_price": money_map_json(&payload.old_other_price),
+        "new_native_price": payload.new_native_price.as_ref().map(price_json),
+        "new_other_price": money_map_json(&payload.new_other_price),
+    })
+}
+
+fn estimate_price_changed_payload_json(
+    payload: &ProductEstimatePriceChangeDomainEventPayload,
+) -> Value {
+    json!({
+        "shop_id": payload.shop_id.to_string(),
+        "seller_id": payload.seller_id.to_string(),
+        "shops_product_id": payload.shops_product_id.to_string(),
+        "native_price_estimate_min": payload.native_price_estimate_min.as_ref().map(price_json),
+        "other_price_estimate_min": money_map_json(&payload.other_price_estimate_min),
+        "native_price_estimate_max": payload.native_price_estimate_max.as_ref().map(price_json),
+        "other_price_estimate_max": money_map_json(&payload.other_price_estimate_max),
+    })
+}
+
+fn images_changed_payload_json(payload: &ProductImagesChangeDomainEventPayload) -> Value {
+    json!({
+        "shop_id": payload.shop_id.to_string(),
+        "seller_id": payload.seller_id.to_string(),
+        "shops_product_id": payload.shops_product_id.to_string(),
+        "images": images_json(&payload.images),
+    })
+}
+
+fn localized_title_json(
+    localized: &Localized<common::language::domain::Language, crate::core::title::Title>,
+) -> Value {
+    json!({
+        "language": localized.localization.as_str(),
+        "text": localized.payload.as_ref(),
+    })
+}
+
+fn localized_description_json(
+    localized: &Localized<
+        common::language::domain::Language,
+        crate::core::description::Description,
+    >,
+) -> Value {
+    json!({
+        "language": localized.localization.as_str(),
+        "text": localized.payload.as_ref(),
+    })
+}
+
+fn structured_address_json(address: &StructuredAddress) -> Value {
+    json!({
+        "addressline": address.addressline,
+        "addressline_extra": address.addressline_extra,
+        "locality": address.locality,
+        "region": address.region,
+        "postal_code": address.postal_code,
+        "country": address.country.map(|country| country.alpha2()),
+    })
+}
+
+fn geo_address_json(address: &GeoAddress) -> Value {
+    json!({
+        "lat": address.lat,
+        "lon": address.lon,
+    })
+}
+
+fn price_json(price: &Price) -> Value {
+    json!({
+        "amount": u64::from(price.monetary_amount),
+        "currency": price.currency.as_str(),
+    })
+}
+
+fn money_map_json(values: &HashMap<Currency, MonetaryAmount>) -> Value {
+    let object = values
+        .iter()
+        .map(|(currency, amount)| (currency.as_str().to_owned(), json!(u64::from(*amount))))
+        .collect();
+    Value::Object(object)
+}
+
+fn images_json(images: &IndexSet<ProductImage>) -> Value {
+    Value::Array(
+        images
+            .iter()
+            .map(|image| {
+                json!({
+                    "url": image.url.as_str(),
+                    "prohibited_content": image.prohibited_content.as_str(),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn shop_type_str(value: shop::core::shop_type::ShopType) -> &'static str {
+    match value {
+        shop::core::shop_type::ShopType::AuctionHouse => "AUCTION_HOUSE",
+        shop::core::shop_type::ShopType::AuctionPlatform => "AUCTION_PLATFORM",
+        shop::core::shop_type::ShopType::CommercialDealer => "COMMERCIAL_DEALER",
+        shop::core::shop_type::ShopType::Marketplace => "MARKETPLACE",
+    }
+}
+
+fn product_state_str(value: common::product_state::domain::ProductState) -> &'static str {
+    match value {
+        common::product_state::domain::ProductState::Listed => "LISTED",
+        common::product_state::domain::ProductState::Available => "AVAILABLE",
+        common::product_state::domain::ProductState::Reserved => "RESERVED",
+        common::product_state::domain::ProductState::Sold => "SOLD",
+        common::product_state::domain::ProductState::Removed => "REMOVED",
+        common::product_state::domain::ProductState::Unknown => "UNKNOWN",
+    }
+}
+
+fn product_lifecycle_str(
+    value: common::product_lifecycle::domain::ProductLifecycle,
+) -> &'static str {
+    match value {
+        common::product_lifecycle::domain::ProductLifecycle::Active => "ACTIVE",
+        common::product_lifecycle::domain::ProductLifecycle::Deleted => "DELETED",
+    }
+}
+
+trait ProductEventKey {
+    fn key(&self) -> ProductKey;
+}
+
+impl ProductEventKey for ProductEventPayload {
+    fn key(&self) -> ProductKey {
+        use common::has_key::HasKey;
+        HasKey::key(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::product::Product;
+    use crate::core::title::Title;
+    use common::language::domain::Language;
+    use common::localized::Localized;
+    use common::product_state::domain::ProductState;
+    use common::shop_name::ShopName;
+    use shop::core::shop_type::ShopType;
+    use url::Url;
+
+    #[test]
+    fn should_map_domain_event_payload_without_transport_fields() {
+        let event = Product::create(
+            ShopId::new(),
+            ShopId::new(),
+            ShopsProductId::from("external-1"),
+            ShopName::from("Shop One"),
+            ShopName::from("Shop One"),
+            ShopType::AuctionHouse,
+            None,
+            None,
+            Localized::new(Language::En, Title::from("A vase")),
+            None,
+            None,
+            Default::default(),
+            None,
+            Default::default(),
+            None,
+            Default::default(),
+            ProductState::Listed,
+            Url::parse("https://shop.example.com/products/external-1").unwrap(),
+            Url::parse("https://aura.example.com/shops/shop-one/products/product-one").unwrap(),
+            [],
+            None,
+            None,
+        );
+        let row = ProductEventRow::from_event(ProductEvent {
+            aggregate_id: event.aggregate_id,
+            event_id: event.event_id,
+            timestamp: event.timestamp,
+            payload: ProductEventPayload::ProductDomainEvent(event.payload),
+        });
+
+        assert_eq!(ProductEventGroup::Domain, row.event_group);
+        assert_eq!("DOMAIN_CREATED", row.event_type);
+        assert!(row.payload.get("pk").is_none());
+        assert!(row.payload.get("event_id").is_none());
+        assert!(row.payload.get("product_slug_id").is_some());
+    }
+}

--- a/src/product/src/postgres/repository.rs
+++ b/src/product/src/postgres/repository.rs
@@ -1,0 +1,931 @@
+use crate::core::description::Description;
+use crate::core::product::Product;
+use crate::core::product_event::domain::ProductDomainEventPayload;
+use crate::core::product_event::{ProductDomainEvent, ProductEvent, ProductEventPayload};
+use crate::core::product_image::ProductImage;
+use crate::core::prohibited_content::ProhibitedContent;
+use crate::core::title::Title;
+use crate::postgres::product_event_row::{ProductEventGroup, ProductEventRow};
+use common::actor::domain::Actor;
+use common::currency::domain::Currency;
+use common::event_id::EventId;
+use common::language::domain::Language;
+use common::localized::Localized;
+use common::price::domain::{MonetaryAmount, Price};
+use common::product_id::{ProductId, ProductKey};
+use common::product_lifecycle::domain::ProductLifecycle;
+use common::product_slug_id::ProductSlugId;
+use common::product_state::domain::ProductState;
+use common::seller_slug_id::SellerSlugId;
+use common::shop_id::ShopId;
+use common::shop_name::ShopName;
+use common::shop_slug_id::ShopSlugId;
+use common::shops_product_id::ShopsProductId;
+use geo::core::address::{GeoAddress, StructuredAddress};
+use geo::core::continent::Continent;
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use shop::core::shop_type::ShopType;
+use sqlx::postgres::{PgQueryResult, PgRow};
+use sqlx::{PgPool, Postgres, QueryBuilder, Row, Transaction};
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use uuid::Uuid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProductPostgresRepositoryError {
+    #[error("failed to map product Postgres row: {0}")]
+    Mapping(String),
+    #[error("failed to serialize product Postgres row")]
+    Serialize(#[from] serde_json::Error),
+    #[error("failed to execute product Postgres query")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("product write conflicted with current event id")]
+    ConcurrentModification,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProductPostgresRepository {
+    pool: PgPool,
+}
+
+impl ProductPostgresRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn get_product(
+        &self,
+        key: &ProductKey,
+    ) -> Result<Option<Product>, ProductPostgresRepositoryError> {
+        let sql = product_select_sql("WHERE shop_id = $1 AND shops_product_id = $2");
+        let row = sqlx::query(&sql)
+            .bind(uuid_from_display(key.shop_id)?)
+            .bind(key.shops_product_id.to_string())
+            .fetch_optional(&self.pool)
+            .await?;
+
+        row.map(product_from_row).transpose()
+    }
+
+    pub async fn get_product_by_id(
+        &self,
+        product_id: ProductId,
+    ) -> Result<Option<Product>, ProductPostgresRepositoryError> {
+        let sql = product_select_sql("WHERE product_id = $1");
+        let row = sqlx::query(&sql)
+            .bind(uuid_from_display(product_id)?)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        row.map(product_from_row).transpose()
+    }
+
+    pub async fn get_event(
+        &self,
+        event_id: EventId,
+    ) -> Result<Option<ProductEventRow>, ProductPostgresRepositoryError> {
+        let row = sqlx::query(product_event_select_sql("WHERE event_id = $1"))
+            .bind(uuid_from_display(event_id)?)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        row.map(product_event_from_row).transpose()
+    }
+
+    pub async fn list_events_for_product(
+        &self,
+        product_id: ProductId,
+    ) -> Result<Vec<ProductEventRow>, ProductPostgresRepositoryError> {
+        let rows = sqlx::query(
+            "SELECT event_id, product_id, shop_id, shops_product_id, event_type, event_group, \
+                    event_type_schema_version, payload, event_time, created_by \
+             FROM product_events WHERE product_id = $1 ORDER BY event_time ASC, event_id ASC",
+        )
+        .bind(uuid_from_display(product_id)?)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(product_event_from_row).collect()
+    }
+
+    pub async fn insert_created_product(
+        &self,
+        event: ProductDomainEvent,
+    ) -> Result<(), ProductPostgresRepositoryError> {
+        let product = product_from_created_event(&event)?;
+        let event = ProductEvent {
+            aggregate_id: event.aggregate_id,
+            event_id: event.event_id,
+            timestamp: event.timestamp,
+            payload: ProductEventPayload::ProductDomainEvent(event.payload),
+        };
+        self.insert_product_with_event(product, event).await
+    }
+
+    pub async fn insert_product_with_event(
+        &self,
+        product: Product,
+        event: ProductEvent,
+    ) -> Result<(), ProductPostgresRepositoryError> {
+        let event_row = ProductEventRow::from_event(event);
+        let mut tx = self.pool.begin().await?;
+
+        insert_product(&mut tx, &product).await?;
+        insert_product_event_row(&mut tx, &event_row).await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn update_product_with_events(
+        &self,
+        mut product: Product,
+        events: Vec<ProductEvent>,
+        expected_event_id: EventId,
+    ) -> Result<(), ProductPostgresRepositoryError> {
+        let Some(last_event) = events.last() else {
+            return Ok(());
+        };
+        product.event_id = last_event.event_id;
+        product.updated = last_event.timestamp;
+        product.updated_by = Actor::System;
+
+        let event_rows = events
+            .into_iter()
+            .map(ProductEventRow::from_event)
+            .collect::<Vec<_>>();
+        self.persist_product_events(product, event_rows, expected_event_id)
+            .await
+    }
+
+    async fn persist_product_events(
+        &self,
+        product: Product,
+        event_rows: Vec<ProductEventRow>,
+        expected_event_id: EventId,
+    ) -> Result<(), ProductPostgresRepositoryError> {
+        if event_rows.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+        for event_row in &event_rows {
+            insert_product_event_row(&mut tx, event_row).await?;
+        }
+        let update = update_product(&mut tx, &product, expected_event_id).await?;
+        if update.rows_affected() != 1 {
+            return Err(ProductPostgresRepositoryError::ConcurrentModification);
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
+fn product_event_select_sql(where_clause: &str) -> &'static str {
+    match where_clause {
+        "WHERE event_id = $1" => {
+            "SELECT event_id, product_id, shop_id, shops_product_id, event_type, event_group, \
+                    event_type_schema_version, payload, event_time, created_by \
+             FROM product_events WHERE event_id = $1"
+        }
+        _ => unreachable!("unsupported product event select"),
+    }
+}
+
+async fn insert_product(
+    tx: &mut Transaction<'_, Postgres>,
+    product: &Product,
+) -> Result<(), ProductPostgresRepositoryError> {
+    let mut query = QueryBuilder::<Postgres>::new("INSERT INTO products (");
+    push_product_columns(&mut query);
+    query.push(") VALUES (");
+    push_product_binds(&mut query, product)?;
+    query.push(")");
+    query.build().execute(&mut **tx).await?;
+    Ok(())
+}
+
+async fn update_product(
+    tx: &mut Transaction<'_, Postgres>,
+    product: &Product,
+    expected_event_id: EventId,
+) -> Result<PgQueryResult, ProductPostgresRepositoryError> {
+    let mut query = QueryBuilder::<Postgres>::new("UPDATE products SET (");
+    push_product_columns(&mut query);
+    query.push(") = (");
+    push_product_binds(&mut query, product)?;
+    query.push(") WHERE shop_id = ");
+    query.push_bind(uuid_from_display(product.shop_id)?);
+    query.push(" AND shops_product_id = ");
+    query.push_bind(product.shops_product_id.to_string());
+    query.push(" AND event_id = ");
+    query.push_bind(uuid_from_display(expected_event_id)?);
+    Ok(query.build().execute(&mut **tx).await?)
+}
+
+async fn insert_product_event_row(
+    tx: &mut Transaction<'_, Postgres>,
+    row: &ProductEventRow,
+) -> Result<(), ProductPostgresRepositoryError> {
+    sqlx::query(
+        "INSERT INTO product_events (
+            event_id, product_id, shop_id, shops_product_id, event_type, event_group,
+            event_type_schema_version, payload, event_time, created_by
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(uuid_from_display(row.event_id)?)
+    .bind(uuid_from_display(row.product_id)?)
+    .bind(uuid_from_display(row.shop_id)?)
+    .bind(row.shops_product_id.to_string())
+    .bind(&row.event_type)
+    .bind(row.event_group.as_str())
+    .bind(row.event_type_schema_version)
+    .bind(sqlx::types::Json(&row.payload))
+    .bind(row.event_time)
+    .bind(String::from(row.created_by))
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+fn push_product_columns(query: &mut QueryBuilder<'_, Postgres>) {
+    let mut columns = query.separated(", ");
+    for column in PRODUCT_COLUMNS {
+        columns.push(*column);
+    }
+}
+
+fn push_product_binds<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    product: &'a Product,
+) -> Result<(), ProductPostgresRepositoryError> {
+    let images = product_images_json(product);
+    let created_by = String::from(product.created_by);
+    let updated_by = String::from(product.updated_by);
+
+    let mut values = query.separated(", ");
+    values.push_bind(uuid_from_display(product.product_id)?);
+    values.push_bind(product.product_slug_id.to_string());
+    values.push_bind(product.shop_slug_id.to_string());
+    values.push_bind(product.seller_slug_id.to_string());
+    values.push_bind(uuid_from_display(product.event_id)?);
+    values.push_bind(uuid_from_display(product.shop_id)?);
+    values.push_bind(uuid_from_display(product.seller_id)?);
+    values.push_bind(product.shops_product_id.to_string());
+    values.push_bind(product.shop_name.to_string());
+    values.push_bind(product.seller_name.to_string());
+    values.push_bind(shop_type_db(product.shop_type));
+    values.push_bind(
+        product
+            .structured_address
+            .as_ref()
+            .and_then(|value| value.addressline.as_deref()),
+    );
+    values.push_bind(
+        product
+            .structured_address
+            .as_ref()
+            .and_then(|value| value.addressline_extra.as_deref()),
+    );
+    values.push_bind(
+        product
+            .structured_address
+            .as_ref()
+            .and_then(|value| value.locality.as_deref()),
+    );
+    values.push_bind(
+        product
+            .structured_address
+            .as_ref()
+            .and_then(|value| value.region.as_deref()),
+    );
+    values.push_bind(
+        product
+            .structured_address
+            .as_ref()
+            .and_then(|value| value.postal_code.as_deref()),
+    );
+    values.push_bind(
+        product
+            .structured_address
+            .as_ref()
+            .and_then(|value| value.country.map(|country| country.alpha2())),
+    );
+    values.push_bind(product.geo_address.map(|value| value.lat));
+    values.push_bind(product.geo_address.map(|value| value.lon));
+    values.push_bind(product.native_title.payload.as_ref());
+    values.push_bind(product.native_title.localization.as_str());
+    values.push_bind(product.other_title.get(&Language::De).map(AsRef::as_ref));
+    values.push_bind(product.other_title.get(&Language::En).map(AsRef::as_ref));
+    values.push_bind(product.other_title.get(&Language::Fr).map(AsRef::as_ref));
+    values.push_bind(product.other_title.get(&Language::Es).map(AsRef::as_ref));
+    values.push_bind(product.other_title.get(&Language::It).map(AsRef::as_ref));
+    values.push_bind(
+        product
+            .native_description
+            .as_ref()
+            .map(|value| value.payload.as_ref()),
+    );
+    values.push_bind(
+        product
+            .native_description
+            .as_ref()
+            .map(|value| value.localization.as_str()),
+    );
+    push_price_binds(&mut values, &product.native_price, &product.other_price)?;
+    push_price_binds(
+        &mut values,
+        &product.native_price_estimate_min,
+        &product.other_price_estimate_min,
+    )?;
+    push_price_binds(
+        &mut values,
+        &product.native_price_estimate_max,
+        &product.other_price_estimate_max,
+    )?;
+    values.push_bind(product_state_db(product.state));
+    values.push_bind(product_lifecycle_db(product.lifecycle));
+    values.push_bind(product.url.as_str());
+    values.push_bind(product.view_url.as_str());
+    values.push_bind(sqlx::types::Json(images));
+    values.push_bind(product.embedding.clone());
+    values.push_bind(product.auction_start);
+    values.push_bind(product.auction_end);
+    values.push_bind(created_by);
+    values.push_bind(updated_by);
+    values.push_bind(product.created);
+    values.push_bind(product.updated);
+    Ok(())
+}
+
+fn push_price_binds<'a>(
+    values: &mut sqlx::query_builder::Separated<'_, 'a, Postgres, &'static str>,
+    native: &'a Option<Price>,
+    other: &'a HashMap<Currency, MonetaryAmount>,
+) -> Result<(), ProductPostgresRepositoryError> {
+    values.push_bind(
+        native
+            .map(|price| i64_from_u64(u64::from(price.monetary_amount)))
+            .transpose()?,
+    );
+    values.push_bind(native.map(|price| price.currency.as_str()));
+    for currency in PRICE_COLUMNS {
+        values.push_bind(
+            other
+                .get(currency)
+                .copied()
+                .map(u64::from)
+                .map(i64_from_u64)
+                .transpose()?,
+        );
+    }
+    Ok(())
+}
+
+fn product_select_sql(where_clause: &str) -> String {
+    format!(
+        "SELECT {} FROM products {}",
+        PRODUCT_COLUMNS.join(", "),
+        where_clause
+    )
+}
+
+fn product_from_created_event(
+    event: &ProductDomainEvent,
+) -> Result<Product, ProductPostgresRepositoryError> {
+    let ProductDomainEventPayload::Created(payload) = event.payload.clone() else {
+        return Err(ProductPostgresRepositoryError::Mapping(
+            "created product insert needs DOMAIN_CREATED event".to_owned(),
+        ));
+    };
+
+    Ok(Product {
+        product_id: event.aggregate_id,
+        product_slug_id: payload.product_slug_id,
+        shop_slug_id: payload.shop_slug_id,
+        seller_slug_id: payload.seller_slug_id,
+        event_id: event.event_id,
+        shop_id: payload.shop_id,
+        seller_id: payload.seller_id,
+        shops_product_id: payload.shops_product_id,
+        shop_name: payload.shop_name,
+        seller_name: payload.seller_name,
+        shop_type: payload.shop_type,
+        structured_address: payload.structured_address,
+        geo_address: payload.geo_address,
+        native_title: payload.native_title,
+        other_title: HashMap::new(),
+        native_description: payload.native_description,
+        native_price: payload.native_price,
+        other_price: payload.other_price,
+        native_price_estimate_min: payload.native_price_estimate_min,
+        other_price_estimate_min: payload.other_price_estimate_min,
+        native_price_estimate_max: payload.native_price_estimate_max,
+        other_price_estimate_max: payload.other_price_estimate_max,
+        state: payload.state,
+        lifecycle: ProductLifecycle::Active,
+        url: payload.url,
+        view_url: payload.view_url,
+        images: payload.images,
+        embedding: None,
+        auction_start: payload.auction_start,
+        auction_end: payload.auction_end,
+        created_by: Actor::System,
+        updated_by: Actor::System,
+        created: event.timestamp,
+        updated: event.timestamp,
+    })
+}
+
+fn product_from_row(row: PgRow) -> Result<Product, ProductPostgresRepositoryError> {
+    let product_id: ProductId = row.get::<Uuid, _>("product_id").into();
+    let shop_id: ShopId = row.get::<Uuid, _>("shop_id").into();
+    let seller_id: ShopId = row.get::<Uuid, _>("seller_id").into();
+    let images: sqlx::types::Json<Value> = row.get("product_images");
+
+    Ok(Product {
+        product_id,
+        product_slug_id: ProductSlugId::from(row.get::<String, _>("product_slug_id")),
+        shop_slug_id: ShopSlugId::from(row.get::<String, _>("shop_slug_id")),
+        seller_slug_id: SellerSlugId::from(row.get::<String, _>("seller_slug_id")),
+        event_id: row.get::<Uuid, _>("event_id").into(),
+        shop_id,
+        seller_id,
+        shops_product_id: ShopsProductId::from(row.get::<String, _>("shops_product_id")),
+        shop_name: ShopName::from(row.get::<String, _>("shop_name")),
+        seller_name: ShopName::from(row.get::<String, _>("seller_name")),
+        shop_type: shop_type_from_db(row.get::<String, _>("shop_type"))?,
+        structured_address: structured_address_from_row(&row)?,
+        geo_address: geo_address_from_row(&row)?,
+        native_title: Localized::new(
+            language_from_db(row.get::<String, _>("title_native_language"))?,
+            Title::from(row.get::<String, _>("title_native_text")),
+        ),
+        other_title: other_titles_from_row(&row),
+        native_description: description_from_row(&row)?,
+        native_price: price_from_row(&row, "price_native_amount", "price_native_currency")?,
+        other_price: money_map_from_row(&row, "price")?,
+        native_price_estimate_min: price_from_row(
+            &row,
+            "price_estimate_min_native_amount",
+            "price_estimate_min_native_currency",
+        )?,
+        other_price_estimate_min: money_map_from_row(&row, "price_estimate_min")?,
+        native_price_estimate_max: price_from_row(
+            &row,
+            "price_estimate_max_native_amount",
+            "price_estimate_max_native_currency",
+        )?,
+        other_price_estimate_max: money_map_from_row(&row, "price_estimate_max")?,
+        state: product_state_from_db(row.get::<String, _>("state"))?,
+        lifecycle: product_lifecycle_from_db(row.get::<String, _>("lifecycle"))?,
+        url: parse_url(row.get::<String, _>("url"), "product url")?,
+        view_url: parse_url(row.get::<String, _>("view_url"), "product view_url")?,
+        images: product_images_from_json(images.0)?,
+        embedding: row.get("embedding"),
+        auction_start: row.get("auction_start"),
+        auction_end: row.get("auction_end"),
+        created_by: Actor::try_from(row.get::<String, _>("created_by"))
+            .map_err(|err| ProductPostgresRepositoryError::Mapping(err.to_string()))?,
+        updated_by: Actor::try_from(row.get::<String, _>("updated_by"))
+            .map_err(|err| ProductPostgresRepositoryError::Mapping(err.to_string()))?,
+        created: row.get("created"),
+        updated: row.get("updated"),
+    })
+}
+
+fn product_event_from_row(row: PgRow) -> Result<ProductEventRow, ProductPostgresRepositoryError> {
+    Ok(ProductEventRow {
+        event_id: row.get::<Uuid, _>("event_id").into(),
+        product_id: row.get::<Uuid, _>("product_id").into(),
+        shop_id: row.get::<Uuid, _>("shop_id").into(),
+        shops_product_id: ShopsProductId::from(row.get::<String, _>("shops_product_id")),
+        event_type: row.get("event_type"),
+        event_group: product_event_group_from_db(row.get::<String, _>("event_group"))?,
+        event_type_schema_version: row.get("event_type_schema_version"),
+        payload: row.get::<sqlx::types::Json<Value>, _>("payload").0,
+        event_time: row.get("event_time"),
+        created_by: Actor::try_from(row.get::<String, _>("created_by"))
+            .map_err(|err| ProductPostgresRepositoryError::Mapping(err.to_string()))?,
+    })
+}
+
+fn structured_address_from_row(
+    row: &PgRow,
+) -> Result<Option<StructuredAddress>, ProductPostgresRepositoryError> {
+    let country = row
+        .get::<Option<String>, _>("structured_address_country")
+        .map(|country| {
+            isocountry::CountryCode::for_alpha2(&country).map_err(|err| {
+                ProductPostgresRepositoryError::Mapping(format!("invalid country code: {err}"))
+            })
+        })
+        .transpose()?;
+    let address = StructuredAddress {
+        addressline: row.get("structured_address_addressline"),
+        addressline_extra: row.get("structured_address_addressline_extra"),
+        locality: row.get("structured_address_locality"),
+        region: row.get("structured_address_region"),
+        postal_code: row.get("structured_address_postal_code"),
+        country,
+        continent: country.map(Continent::from),
+    };
+    Ok((!address.is_empty()).then_some(address))
+}
+
+fn geo_address_from_row(row: &PgRow) -> Result<Option<GeoAddress>, ProductPostgresRepositoryError> {
+    match (
+        row.get::<Option<f64>, _>("geo_address_lat"),
+        row.get::<Option<f64>, _>("geo_address_lon"),
+    ) {
+        (Some(lat), Some(lon)) => Ok(Some(GeoAddress { lat, lon })),
+        (None, None) => Ok(None),
+        _ => Err(ProductPostgresRepositoryError::Mapping(
+            "geo lat and lon must both be present".to_owned(),
+        )),
+    }
+}
+
+fn other_titles_from_row(row: &PgRow) -> HashMap<Language, Title> {
+    [
+        (Language::De, row.get::<Option<String>, _>("title_de")),
+        (Language::En, row.get::<Option<String>, _>("title_en")),
+        (Language::Fr, row.get::<Option<String>, _>("title_fr")),
+        (Language::Es, row.get::<Option<String>, _>("title_es")),
+        (Language::It, row.get::<Option<String>, _>("title_it")),
+    ]
+    .into_iter()
+    .filter_map(|(language, title)| title.map(|title| (language, Title::from(title))))
+    .collect()
+}
+
+fn description_from_row(
+    row: &PgRow,
+) -> Result<Option<Localized<Language, Description>>, ProductPostgresRepositoryError> {
+    match (
+        row.get::<Option<String>, _>("description_native_text"),
+        row.get::<Option<String>, _>("description_native_language"),
+    ) {
+        (Some(text), Some(language)) => Ok(Some(Localized::new(
+            language_from_db(language)?,
+            Description::from(text),
+        ))),
+        (None, None) => Ok(None),
+        _ => Err(ProductPostgresRepositoryError::Mapping(
+            "description text and language must both be present".to_owned(),
+        )),
+    }
+}
+
+fn price_from_row(
+    row: &PgRow,
+    amount_column: &str,
+    currency_column: &str,
+) -> Result<Option<Price>, ProductPostgresRepositoryError> {
+    match (
+        row.get::<Option<i64>, _>(amount_column),
+        row.get::<Option<String>, _>(currency_column),
+    ) {
+        (Some(amount), Some(currency)) => Ok(Some(Price::new(
+            u64_from_i64(amount)?.into(),
+            currency_from_db(currency)?,
+        ))),
+        (None, None) => Ok(None),
+        _ => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "{amount_column} and {currency_column} must both be present"
+        ))),
+    }
+}
+
+fn money_map_from_row(
+    row: &PgRow,
+    prefix: &str,
+) -> Result<HashMap<Currency, MonetaryAmount>, ProductPostgresRepositoryError> {
+    let mut result = HashMap::new();
+    for currency in PRICE_COLUMNS {
+        let column = format!("{}_{}", prefix, currency.as_str().to_ascii_lowercase());
+        if let Some(amount) = row.get::<Option<i64>, _>(column.as_str()) {
+            result.insert(*currency, u64_from_i64(amount)?.into());
+        }
+    }
+    Ok(result)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProductImageJson {
+    url: String,
+    prohibited_content: String,
+}
+
+fn product_images_json(product: &Product) -> Vec<ProductImageJson> {
+    product
+        .images
+        .iter()
+        .map(|image| ProductImageJson {
+            url: image.url.to_string(),
+            prohibited_content: image.prohibited_content.as_str().to_owned(),
+        })
+        .collect()
+}
+
+fn product_images_from_json(
+    value: Value,
+) -> Result<IndexSet<ProductImage>, ProductPostgresRepositoryError> {
+    let images: Vec<ProductImageJson> = serde_json::from_value(value)?;
+    images
+        .into_iter()
+        .map(|image| {
+            Ok(ProductImage {
+                url: parse_url(image.url, "product image url")?,
+                prohibited_content: prohibited_content_from_db(image.prohibited_content)?,
+            })
+        })
+        .collect()
+}
+
+fn parse_url(value: String, field: &str) -> Result<url::Url, ProductPostgresRepositoryError> {
+    value
+        .parse()
+        .map_err(|err| ProductPostgresRepositoryError::Mapping(format!("invalid {field}: {err}")))
+}
+
+fn shop_type_db(value: ShopType) -> &'static str {
+    match value {
+        ShopType::AuctionHouse => "AUCTION_HOUSE",
+        ShopType::AuctionPlatform => "AUCTION_PLATFORM",
+        ShopType::CommercialDealer => "COMMERCIAL_DEALER",
+        ShopType::Marketplace => "MARKETPLACE",
+    }
+}
+
+fn shop_type_from_db(value: String) -> Result<ShopType, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "AUCTION_HOUSE" => Ok(ShopType::AuctionHouse),
+        "AUCTION_PLATFORM" => Ok(ShopType::AuctionPlatform),
+        "COMMERCIAL_DEALER" => Ok(ShopType::CommercialDealer),
+        "MARKETPLACE" => Ok(ShopType::Marketplace),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown shop type: {other}"
+        ))),
+    }
+}
+
+fn product_state_db(value: ProductState) -> &'static str {
+    match value {
+        ProductState::Listed => "LISTED",
+        ProductState::Available => "AVAILABLE",
+        ProductState::Reserved => "RESERVED",
+        ProductState::Sold => "SOLD",
+        ProductState::Removed => "REMOVED",
+        ProductState::Unknown => "UNKNOWN",
+    }
+}
+
+fn product_state_from_db(value: String) -> Result<ProductState, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "LISTED" => Ok(ProductState::Listed),
+        "AVAILABLE" => Ok(ProductState::Available),
+        "RESERVED" => Ok(ProductState::Reserved),
+        "SOLD" => Ok(ProductState::Sold),
+        "REMOVED" => Ok(ProductState::Removed),
+        "UNKNOWN" => Ok(ProductState::Unknown),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown product state: {other}"
+        ))),
+    }
+}
+
+fn product_lifecycle_db(value: ProductLifecycle) -> &'static str {
+    match value {
+        ProductLifecycle::Active => "ACTIVE",
+        ProductLifecycle::Deleted => "DELETED",
+    }
+}
+
+fn product_lifecycle_from_db(
+    value: String,
+) -> Result<ProductLifecycle, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "ACTIVE" => Ok(ProductLifecycle::Active),
+        "DELETED" => Ok(ProductLifecycle::Deleted),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown product lifecycle: {other}"
+        ))),
+    }
+}
+
+fn product_event_group_from_db(
+    value: String,
+) -> Result<ProductEventGroup, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "DOMAIN" => Ok(ProductEventGroup::Domain),
+        "ENRICHMENT" => Ok(ProductEventGroup::Enrichment),
+        "POLICY" => Ok(ProductEventGroup::Policy),
+        "LIFECYCLE" => Ok(ProductEventGroup::Lifecycle),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown product event group: {other}"
+        ))),
+    }
+}
+
+fn language_from_db(value: String) -> Result<Language, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "de" => Ok(Language::De),
+        "en" => Ok(Language::En),
+        "fr" => Ok(Language::Fr),
+        "es" => Ok(Language::Es),
+        "it" => Ok(Language::It),
+        "zh" => Ok(Language::Zh),
+        "pt" => Ok(Language::Pt),
+        "pl" => Ok(Language::Pl),
+        "tr" => Ok(Language::Tr),
+        "nl" => Ok(Language::Nl),
+        "cs" => Ok(Language::Cs),
+        "ja" => Ok(Language::Ja),
+        "ru" => Ok(Language::Ru),
+        "ar" => Ok(Language::Ar),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown language: {other}"
+        ))),
+    }
+}
+
+fn currency_from_db(value: String) -> Result<Currency, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "EUR" => Ok(Currency::Eur),
+        "GBP" => Ok(Currency::Gbp),
+        "USD" => Ok(Currency::Usd),
+        "AUD" => Ok(Currency::Aud),
+        "CAD" => Ok(Currency::Cad),
+        "NZD" => Ok(Currency::Nzd),
+        "CNY" => Ok(Currency::Cny),
+        "BRL" => Ok(Currency::Brl),
+        "PLN" => Ok(Currency::Pln),
+        "TRY" => Ok(Currency::Try),
+        "JPY" => Ok(Currency::Jpy),
+        "CZK" => Ok(Currency::Czk),
+        "RUB" => Ok(Currency::Rub),
+        "AED" => Ok(Currency::Aed),
+        "SAR" => Ok(Currency::Sar),
+        "HKD" => Ok(Currency::Hkd),
+        "SGD" => Ok(Currency::Sgd),
+        "CHF" => Ok(Currency::Chf),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown currency: {other}"
+        ))),
+    }
+}
+
+fn prohibited_content_from_db(
+    value: String,
+) -> Result<ProhibitedContent, ProductPostgresRepositoryError> {
+    match value.as_str() {
+        "UNKNOWN" => Ok(ProhibitedContent::Unknown),
+        "NONE" => Ok(ProhibitedContent::None),
+        "NAZI_GERMANY" => Ok(ProhibitedContent::NaziGermany),
+        other => Err(ProductPostgresRepositoryError::Mapping(format!(
+            "unknown prohibited content: {other}"
+        ))),
+    }
+}
+
+fn uuid_from_display(value: impl Display) -> Result<Uuid, ProductPostgresRepositoryError> {
+    Uuid::parse_str(&value.to_string())
+        .map_err(|err| ProductPostgresRepositoryError::Mapping(err.to_string()))
+}
+
+fn i64_from_u64(value: u64) -> Result<i64, ProductPostgresRepositoryError> {
+    i64::try_from(value).map_err(|err| ProductPostgresRepositoryError::Mapping(err.to_string()))
+}
+
+fn u64_from_i64(value: i64) -> Result<u64, ProductPostgresRepositoryError> {
+    u64::try_from(value).map_err(|err| ProductPostgresRepositoryError::Mapping(err.to_string()))
+}
+
+const PRICE_COLUMNS: &[Currency] = &[
+    Currency::Eur,
+    Currency::Usd,
+    Currency::Gbp,
+    Currency::Aud,
+    Currency::Cad,
+    Currency::Nzd,
+    Currency::Cny,
+    Currency::Brl,
+    Currency::Pln,
+    Currency::Try,
+    Currency::Jpy,
+    Currency::Czk,
+    Currency::Rub,
+    Currency::Aed,
+    Currency::Sar,
+    Currency::Hkd,
+    Currency::Sgd,
+    Currency::Chf,
+];
+
+const PRODUCT_COLUMNS: &[&str] = &[
+    "product_id",
+    "product_slug_id",
+    "shop_slug_id",
+    "seller_slug_id",
+    "event_id",
+    "shop_id",
+    "seller_id",
+    "shops_product_id",
+    "shop_name",
+    "seller_name",
+    "shop_type",
+    "structured_address_addressline",
+    "structured_address_addressline_extra",
+    "structured_address_locality",
+    "structured_address_region",
+    "structured_address_postal_code",
+    "structured_address_country",
+    "geo_address_lat",
+    "geo_address_lon",
+    "title_native_text",
+    "title_native_language",
+    "title_de",
+    "title_en",
+    "title_fr",
+    "title_es",
+    "title_it",
+    "description_native_text",
+    "description_native_language",
+    "price_native_amount",
+    "price_native_currency",
+    "price_eur",
+    "price_usd",
+    "price_gbp",
+    "price_aud",
+    "price_cad",
+    "price_nzd",
+    "price_cny",
+    "price_brl",
+    "price_pln",
+    "price_try",
+    "price_jpy",
+    "price_czk",
+    "price_rub",
+    "price_aed",
+    "price_sar",
+    "price_hkd",
+    "price_sgd",
+    "price_chf",
+    "price_estimate_min_native_amount",
+    "price_estimate_min_native_currency",
+    "price_estimate_min_eur",
+    "price_estimate_min_usd",
+    "price_estimate_min_gbp",
+    "price_estimate_min_aud",
+    "price_estimate_min_cad",
+    "price_estimate_min_nzd",
+    "price_estimate_min_cny",
+    "price_estimate_min_brl",
+    "price_estimate_min_pln",
+    "price_estimate_min_try",
+    "price_estimate_min_jpy",
+    "price_estimate_min_czk",
+    "price_estimate_min_rub",
+    "price_estimate_min_aed",
+    "price_estimate_min_sar",
+    "price_estimate_min_hkd",
+    "price_estimate_min_sgd",
+    "price_estimate_min_chf",
+    "price_estimate_max_native_amount",
+    "price_estimate_max_native_currency",
+    "price_estimate_max_eur",
+    "price_estimate_max_usd",
+    "price_estimate_max_gbp",
+    "price_estimate_max_aud",
+    "price_estimate_max_cad",
+    "price_estimate_max_nzd",
+    "price_estimate_max_cny",
+    "price_estimate_max_brl",
+    "price_estimate_max_pln",
+    "price_estimate_max_try",
+    "price_estimate_max_jpy",
+    "price_estimate_max_czk",
+    "price_estimate_max_rub",
+    "price_estimate_max_aed",
+    "price_estimate_max_sar",
+    "price_estimate_max_hkd",
+    "price_estimate_max_sgd",
+    "price_estimate_max_chf",
+    "state",
+    "lifecycle",
+    "url",
+    "view_url",
+    "product_images",
+    "embedding",
+    "auction_start",
+    "auction_end",
+    "created_by",
+    "updated_by",
+    "created",
+    "updated",
+];

--- a/src/product/src/service/mod.rs
+++ b/src/product/src/service/mod.rs
@@ -5,6 +5,9 @@ pub mod command_service;
 pub mod get_service;
 pub mod product_command;
 
+#[cfg(all(feature = "postgres", feature = "service"))]
+pub mod product_service;
+
 #[cfg(feature = "opensearch")]
 pub mod query_service;
 

--- a/src/product/src/service/product_service.rs
+++ b/src/product/src/service/product_service.rs
@@ -1,0 +1,440 @@
+use crate::core::product::Product;
+use crate::core::product_event::{
+    ProductDomainEvent, ProductEnrichmentEvent, ProductEvent, ProductEventPayload,
+    ProductLifecycleEvent, ProductPolicyEvent,
+};
+use crate::postgres::{ProductPostgresRepository, ProductPostgresRepositoryError};
+use crate::service::product_command::{
+    CreateProductCommand, Translation, UpdateProductCommand, UpsertProductCommand,
+};
+use async_trait::async_trait;
+use common::has_key::HasKey;
+use common::mergeable::Mergeable;
+use common::price::domain::FxRate;
+use common::product_id::ProductKey;
+use common::shop_id::ShopId;
+use common::shop_name::ShopName;
+use common::utm::append_utm_params;
+use fxrate::dynamodb::record::FxRatesRecord;
+use fxrate::service::{FxRateService, FxRateServiceError};
+use shop::core::affiliate_configuration::AffiliateConfiguration;
+use shop::core::shop_type::ShopType;
+use shop::service::get_service::GetShopService;
+use std::collections::HashMap;
+use tracing::warn;
+
+#[async_trait]
+pub trait ProductService {
+    async fn create(&self, cmds: Vec<CreateProductCommand>) -> Vec<CreateProductCommand>;
+    async fn update(
+        &self,
+        cmds: HashMap<ProductKey, UpdateProductCommand>,
+    ) -> HashMap<ProductKey, UpdateProductCommand>;
+    async fn upsert(&self, cmds: Vec<UpsertProductCommand>) -> Vec<UpsertProductCommand>;
+    async fn delete(&self, product_key: &ProductKey) -> Result<(), DeleteProductError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeleteProductError {
+    #[error("Product not found")]
+    NotFound,
+    #[error("Failed loading product before delete: {0}")]
+    Load(String),
+    #[error("Failed product delete transaction: {0}")]
+    Persist(String),
+}
+
+pub struct ProductServiceImpl<'a> {
+    postgres_repository: &'a ProductPostgresRepository,
+    fx_rate: FxRatesRecord,
+    get_shop_service: &'a (dyn GetShopService + Sync),
+}
+
+struct ResolvedShopInformation {
+    seller_id: ShopId,
+    seller_name: ShopName,
+    shop_name: ShopName,
+    shop_type: ShopType,
+    affiliate_configuration: Option<AffiliateConfiguration>,
+}
+
+impl<'a> ProductServiceImpl<'a> {
+    pub async fn new(
+        postgres_repository: &'a ProductPostgresRepository,
+        fx_rate_service: &(dyn FxRateService + Sync),
+        get_shop_service: &'a (dyn GetShopService + Sync),
+    ) -> Result<Self, FxRateServiceError> {
+        let fx_rate = fx_rate_service.get_current().await?;
+        Ok(Self {
+            postgres_repository,
+            fx_rate,
+            get_shop_service,
+        })
+    }
+
+    pub fn new_with_fx_rate(
+        postgres_repository: &'a ProductPostgresRepository,
+        fx_rate: FxRatesRecord,
+        get_shop_service: &'a (dyn GetShopService + Sync),
+    ) -> Self {
+        Self {
+            postgres_repository,
+            fx_rate,
+            get_shop_service,
+        }
+    }
+
+    fn enrich_price(&self, cmd: &mut CreateProductCommand) {
+        if let Some(price) = &cmd.native_price {
+            match self
+                .fx_rate
+                .exchange_all(price.currency, price.monetary_amount)
+            {
+                Ok(other) => cmd.other_price = other,
+                Err(err) => {
+                    warn!(error = %err, "Failed to convert native_price. Defaulting to empty.")
+                }
+            }
+        }
+        if let Some(price) = &cmd.native_price_estimate_min {
+            match self
+                .fx_rate
+                .exchange_all(price.currency, price.monetary_amount)
+            {
+                Ok(other) => cmd.other_price_estimate_min = other,
+                Err(err) => {
+                    warn!(error = %err, "Failed to convert native_price_estimate_min. Defaulting to empty.")
+                }
+            }
+        }
+        if let Some(price) = &cmd.native_price_estimate_max {
+            match self
+                .fx_rate
+                .exchange_all(price.currency, price.monetary_amount)
+            {
+                Ok(other) => cmd.other_price_estimate_max = other,
+                Err(err) => {
+                    warn!(error = %err, "Failed to convert native_price_estimate_max. Defaulting to empty.")
+                }
+            }
+        }
+    }
+
+    async fn enrich_shop_information(
+        &self,
+        cmd: &mut CreateProductCommand,
+    ) -> Option<ResolvedShopInformation> {
+        let shop = match self.get_shop_service.find_shop(&cmd.shop_id).await {
+            Ok(shop) => shop,
+            Err(err) => {
+                warn!(
+                    error = ?err,
+                    shopId = %cmd.shop_id,
+                    shopsProductId = %cmd.shops_product_id,
+                    "Failed resolving shop information for product command."
+                );
+                return None;
+            }
+        };
+
+        if cmd.structured_address.is_none() && cmd.geo_address.is_none() {
+            cmd.structured_address = shop.structured_address.clone();
+            cmd.geo_address = shop.geo_address;
+        }
+
+        Some(ResolvedShopInformation {
+            seller_id: shop.shop_id,
+            seller_name: shop.name.clone(),
+            shop_name: shop.name,
+            shop_type: shop.shop_type,
+            affiliate_configuration: shop.affiliate_configuration,
+        })
+    }
+
+    async fn create_one(&self, mut cmd: CreateProductCommand) -> Result<(), CreateProductCommand> {
+        match self.postgres_repository.get_product(&cmd.key()).await {
+            Ok(Some(_)) => return Ok(()),
+            Ok(None) => {}
+            Err(err) => {
+                warn!(error = ?err, "Failed loading product before create.");
+                return Err(cmd);
+            }
+        }
+
+        let Some(resolved) = self.enrich_shop_information(&mut cmd).await else {
+            return Err(cmd);
+        };
+        self.enrich_price(&mut cmd);
+        let view_url = resolved
+            .affiliate_configuration
+            .as_ref()
+            .map(|configuration| configuration.build_url(&cmd.url))
+            .unwrap_or_else(|| append_utm_params(cmd.url.clone()));
+        let failure_cmd = cmd.clone();
+        let create_event = Product::create(
+            cmd.shop_id,
+            resolved.seller_id,
+            cmd.shops_product_id.clone(),
+            resolved.shop_name,
+            resolved.seller_name,
+            resolved.shop_type,
+            cmd.structured_address,
+            cmd.geo_address,
+            cmd.native_title,
+            cmd.native_description,
+            cmd.native_price,
+            cmd.other_price,
+            cmd.native_price_estimate_min,
+            cmd.other_price_estimate_min,
+            cmd.native_price_estimate_max,
+            cmd.other_price_estimate_max,
+            cmd.state,
+            cmd.url,
+            view_url,
+            cmd.images,
+            cmd.auction_start,
+            cmd.auction_end,
+        );
+
+        match self
+            .postgres_repository
+            .insert_created_product(create_event)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                warn!(error = ?err, "Failed product create transaction.");
+                Err(failure_cmd)
+            }
+        }
+    }
+
+    async fn update_one(
+        &self,
+        key: ProductKey,
+        cmd: UpdateProductCommand,
+    ) -> Result<(), (ProductKey, UpdateProductCommand)> {
+        let mut product = match self.postgres_repository.get_product(&key).await {
+            Ok(Some(product)) => product,
+            Ok(None) => return Err((key, cmd)),
+            Err(err) => {
+                warn!(error = ?err, "Failed loading product before update.");
+                return Err((key, cmd));
+            }
+        };
+        let expected_event_id = product.event_id;
+        let events = determine_update_events(&mut product, cmd.clone(), &self.fx_rate);
+        if events.is_empty() {
+            return Ok(());
+        }
+        match self
+            .postgres_repository
+            .update_product_with_events(product, events, expected_event_id)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                warn!(error = ?err, "Failed product update transaction.");
+                Err((key, cmd))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ProductService for ProductServiceImpl<'_> {
+    async fn create(&self, cmds: Vec<CreateProductCommand>) -> Vec<CreateProductCommand> {
+        let mut by_key = HashMap::<ProductKey, CreateProductCommand>::new();
+        for cmd in cmds {
+            by_key.insert(cmd.key(), cmd);
+        }
+
+        let mut failures = Vec::new();
+        for cmd in by_key.into_values() {
+            if let Err(cmd) = self.create_one(cmd).await {
+                failures.push(cmd);
+            }
+        }
+        failures
+    }
+
+    async fn update(
+        &self,
+        cmds: HashMap<ProductKey, UpdateProductCommand>,
+    ) -> HashMap<ProductKey, UpdateProductCommand> {
+        let mut merged = HashMap::<ProductKey, UpdateProductCommand>::new();
+        for (key, cmd) in cmds {
+            match merged.entry(key) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().merge(cmd)
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(cmd);
+                }
+            }
+        }
+
+        let mut failures = HashMap::new();
+        for (key, cmd) in merged {
+            if let Err((key, cmd)) = self.update_one(key, cmd).await {
+                failures.insert(key, cmd);
+            }
+        }
+        failures
+    }
+
+    async fn upsert(&self, cmds: Vec<UpsertProductCommand>) -> Vec<UpsertProductCommand> {
+        let mut merged = HashMap::<ProductKey, UpsertProductCommand>::new();
+        for cmd in cmds {
+            match merged.entry(cmd.key()) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().merge(cmd)
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(cmd);
+                }
+            }
+        }
+
+        let mut failures = Vec::new();
+        for (key, cmd) in merged {
+            match self.postgres_repository.get_product(&key).await {
+                Ok(Some(_)) => {
+                    if self
+                        .update_one(key, UpdateProductCommand::from(&cmd))
+                        .await
+                        .is_err()
+                    {
+                        failures.push(cmd);
+                    }
+                }
+                Ok(None) => {
+                    if self
+                        .create_one(CreateProductCommand::from(cmd.clone()))
+                        .await
+                        .is_err()
+                    {
+                        failures.push(cmd);
+                    }
+                }
+                Err(err) => {
+                    warn!(error = ?err, "Failed loading product before upsert.");
+                    failures.push(cmd);
+                }
+            }
+        }
+        failures
+    }
+
+    async fn delete(&self, product_key: &ProductKey) -> Result<(), DeleteProductError> {
+        let mut product = self
+            .postgres_repository
+            .get_product(product_key)
+            .await
+            .map_err(|err| DeleteProductError::Load(err.to_string()))?
+            .ok_or(DeleteProductError::NotFound)?;
+        let expected_event_id = product.event_id;
+        let Some(event) = product.delete() else {
+            return Ok(());
+        };
+        self.postgres_repository
+            .update_product_with_events(product, vec![lifecycle_event(event)], expected_event_id)
+            .await
+            .map_err(|err| DeleteProductError::Persist(err.to_string()))
+    }
+}
+
+fn determine_update_events(
+    product: &mut Product,
+    cmd: UpdateProductCommand,
+    fx_rate: &impl FxRate,
+) -> Vec<ProductEvent> {
+    let mut events = Vec::new();
+    if let Some(new_native_price) = cmd.native_price
+        && let Some(event) = product.change_price(new_native_price, fx_rate)
+    {
+        events.push(domain_event(event));
+    }
+    if let Some(new_state) = cmd.state
+        && let Some(event) = product.change_state(new_state)
+    {
+        events.push(domain_event(event));
+    }
+    if let Some(event) = product.change_estimate_price(
+        cmd.native_price_estimate_min,
+        cmd.native_price_estimate_max,
+        fx_rate,
+    ) {
+        events.push(domain_event(event));
+    }
+    if let Some(url) = cmd.url
+        && let Some(event) = product.change_url(url.clone(), append_utm_params(url))
+    {
+        events.push(domain_event(event));
+    }
+    if let Some(images) = cmd.images {
+        events.extend(product.change_images(images));
+    }
+    if (cmd.auction_start.is_some() || cmd.auction_end.is_some())
+        && let Some(event) = product.change_auction_time(cmd.auction_start, cmd.auction_end)
+    {
+        events.push(domain_event(event));
+    }
+    if let Some(embedding) = cmd.embedding
+        && let Some(event) = product.embed(embedding)
+    {
+        events.push(enrichment_event(event));
+    }
+    if let Some(Translation { source, targets }) = cmd.translated_titles {
+        let source_language = source.localization;
+        for (target_language, title) in targets {
+            if let Some(event) = product.translate_title(source_language, target_language, title) {
+                events.push(enrichment_event(event));
+            }
+        }
+    }
+    events
+}
+
+fn domain_event(event: ProductDomainEvent) -> ProductEvent {
+    ProductEvent {
+        aggregate_id: event.aggregate_id,
+        event_id: event.event_id,
+        timestamp: event.timestamp,
+        payload: ProductEventPayload::ProductDomainEvent(event.payload),
+    }
+}
+
+fn enrichment_event(event: ProductEnrichmentEvent) -> ProductEvent {
+    ProductEvent {
+        aggregate_id: event.aggregate_id,
+        event_id: event.event_id,
+        timestamp: event.timestamp,
+        payload: ProductEventPayload::ProductEnrichmentEvent(event.payload),
+    }
+}
+
+#[allow(dead_code)]
+fn policy_event(event: ProductPolicyEvent) -> ProductEvent {
+    ProductEvent {
+        aggregate_id: event.aggregate_id,
+        event_id: event.event_id,
+        timestamp: event.timestamp,
+        payload: ProductEventPayload::ProductPolicyEvent(event.payload),
+    }
+}
+
+fn lifecycle_event(event: ProductLifecycleEvent) -> ProductEvent {
+    ProductEvent {
+        aggregate_id: event.aggregate_id,
+        event_id: event.event_id,
+        timestamp: event.timestamp,
+        payload: ProductEventPayload::ProductLifecycleEvent(event.payload),
+    }
+}
+
+impl From<ProductPostgresRepositoryError> for DeleteProductError {
+    fn from(value: ProductPostgresRepositoryError) -> Self {
+        Self::Persist(value.to_string())
+    }
+}

--- a/src/product/tests/product_postgres_repository.rs
+++ b/src/product/tests/product_postgres_repository.rs
@@ -1,0 +1,257 @@
+use common::language::domain::Language;
+use common::localized::Localized;
+use common::product_lifecycle::domain::ProductLifecycle;
+use common::product_state::domain::ProductState;
+use common::shop_id::ShopId;
+use common::shop_name::ShopName;
+use common::shops_product_id::ShopsProductId;
+use product::core::product::Product;
+use product::core::product_event::{ProductDomainEvent, ProductEvent, ProductEventPayload};
+use product::core::product_image::ProductImage;
+use product::core::prohibited_content::ProhibitedContent;
+use product::core::title::Title;
+use product::postgres::{
+    ProductEventGroup, ProductPostgresRepository, ProductPostgresRepositoryError,
+};
+use serial_test::serial;
+use shop::core::shop_type::ShopType;
+use sqlx::PgPool;
+use test_api::*;
+use url::Url;
+
+const BUSINESS_SCHEMA: Postgres = Postgres::new("migrations");
+
+#[serial]
+#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+async fn should_insert_product_and_event_in_one_transaction() {
+    let pool = get_postgres_client().await;
+    let shop_id = ShopId::new();
+    insert_shop(&pool, shop_id).await;
+    let event_record = created_event_record(shop_id, "external-1");
+    let product_id = event_record.aggregate_id;
+    let event_id = event_record.event_id;
+    let repository = ProductPostgresRepository::new(pool.clone());
+
+    repository
+        .insert_created_product(event_record)
+        .await
+        .unwrap();
+
+    let product = repository
+        .get_product(&common::product_id::ProductKey::new(
+            shop_id,
+            ShopsProductId::from("external-1"),
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    let events = repository
+        .list_events_for_product(product_id)
+        .await
+        .unwrap();
+
+    assert_eq!(product_id, product.product_id);
+    assert_eq!(event_id, product.event_id);
+    assert_eq!(ProductState::Listed, product.state);
+    assert_eq!(2, product.images.len());
+    assert_eq!(
+        vec![
+            "https://cdn.example.com/one.jpg",
+            "https://cdn.example.com/two.jpg"
+        ],
+        product
+            .images
+            .iter()
+            .map(|image| image.url.as_str())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(1, events.len());
+    assert_eq!(ProductEventGroup::Domain, events[0].event_group);
+    assert_eq!("DOMAIN_CREATED", events[0].event_type);
+    assert!(events[0].payload.get("product_slug_id").is_some());
+}
+
+#[serial]
+#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+async fn should_update_product_and_append_event_in_one_transaction() {
+    let pool = get_postgres_client().await;
+    let shop_id = ShopId::new();
+    insert_shop(&pool, shop_id).await;
+    let event_record = created_event_record(shop_id, "external-2");
+    let product_id = event_record.aggregate_id;
+    let repository = ProductPostgresRepository::new(pool.clone());
+    repository
+        .insert_created_product(event_record)
+        .await
+        .unwrap();
+    let key = common::product_id::ProductKey::new(shop_id, ShopsProductId::from("external-2"));
+    let mut product = repository.get_product(&key).await.unwrap().unwrap();
+    let expected_event_id = product.event_id;
+    let update_event = product.change_state(ProductState::Sold).unwrap();
+    let update_event_id = update_event.event_id;
+
+    repository
+        .update_product_with_events(product, vec![domain_event(update_event)], expected_event_id)
+        .await
+        .unwrap();
+
+    let product = repository.get_product(&key).await.unwrap().unwrap();
+    let events = repository
+        .list_events_for_product(product_id)
+        .await
+        .unwrap();
+
+    assert_eq!(ProductState::Sold, product.state);
+    assert_eq!(update_event_id, product.event_id);
+    assert_eq!(2, events.len());
+    assert_eq!("DOMAIN_STATE_CHANGED", events[1].event_type);
+}
+
+#[serial]
+#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+async fn should_update_product_and_append_delete_event_in_one_transaction() {
+    let pool = get_postgres_client().await;
+    let shop_id = ShopId::new();
+    insert_shop(&pool, shop_id).await;
+    let event_record = created_event_record(shop_id, "external-delete");
+    let product_id = event_record.aggregate_id;
+    let repository = ProductPostgresRepository::new(pool.clone());
+    repository
+        .insert_created_product(event_record)
+        .await
+        .unwrap();
+    let key = common::product_id::ProductKey::new(shop_id, ShopsProductId::from("external-delete"));
+    let mut product = repository.get_product(&key).await.unwrap().unwrap();
+    let expected_event_id = product.event_id;
+    let delete_event = product.delete().unwrap();
+    let delete_event_id = delete_event.event_id;
+
+    repository
+        .update_product_with_events(
+            product,
+            vec![lifecycle_event(delete_event)],
+            expected_event_id,
+        )
+        .await
+        .unwrap();
+
+    let product = repository.get_product(&key).await.unwrap().unwrap();
+    let events = repository
+        .list_events_for_product(product_id)
+        .await
+        .unwrap();
+
+    assert_eq!(ProductLifecycle::Deleted, product.lifecycle);
+    assert_eq!(delete_event_id, product.event_id);
+    assert_eq!(2, events.len());
+    assert_eq!(ProductEventGroup::Lifecycle, events[1].event_group);
+    assert_eq!("LIFECYCLE_DELETED", events[1].event_type);
+}
+
+#[serial]
+#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+async fn should_reject_update_when_expected_event_id_is_stale() {
+    let pool = get_postgres_client().await;
+    let shop_id = ShopId::new();
+    insert_shop(&pool, shop_id).await;
+    let event_record = created_event_record(shop_id, "external-3");
+    let product_id = event_record.aggregate_id;
+    let repository = ProductPostgresRepository::new(pool.clone());
+    repository
+        .insert_created_product(event_record)
+        .await
+        .unwrap();
+    let key = common::product_id::ProductKey::new(shop_id, ShopsProductId::from("external-3"));
+    let mut product = repository.get_product(&key).await.unwrap().unwrap();
+    let update_event = product.change_state(ProductState::Sold).unwrap();
+
+    let error = repository
+        .update_product_with_events(
+            product,
+            vec![domain_event(update_event)],
+            common::event_id::EventId::new(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ProductPostgresRepositoryError::ConcurrentModification
+    ));
+    let events = repository
+        .list_events_for_product(product_id)
+        .await
+        .unwrap();
+    assert_eq!(1, events.len());
+}
+
+fn domain_event(event: ProductDomainEvent) -> ProductEvent {
+    ProductEvent {
+        aggregate_id: event.aggregate_id,
+        event_id: event.event_id,
+        timestamp: event.timestamp,
+        payload: ProductEventPayload::ProductDomainEvent(event.payload),
+    }
+}
+
+fn lifecycle_event(event: product::core::product_event::ProductLifecycleEvent) -> ProductEvent {
+    ProductEvent {
+        aggregate_id: event.aggregate_id,
+        event_id: event.event_id,
+        timestamp: event.timestamp,
+        payload: ProductEventPayload::ProductLifecycleEvent(event.payload),
+    }
+}
+
+async fn insert_shop(pool: &PgPool, shop_id: ShopId) {
+    sqlx::query(
+        "INSERT INTO shops (shop_id, shop_slug_id, name, shop_type, partner_status, created_by, updated_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(uuid::Uuid::from(shop_id))
+    .bind(format!("shop-{shop_id}"))
+    .bind("Shop One")
+    .bind("AUCTION_HOUSE")
+    .bind("PARTNERED")
+    .bind("SYSTEM")
+    .bind("SYSTEM")
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn created_event_record(shop_id: ShopId, shops_product_id: &str) -> ProductDomainEvent {
+    Product::create(
+        shop_id,
+        shop_id,
+        ShopsProductId::from(shops_product_id),
+        ShopName::from("Shop One"),
+        ShopName::from("Shop One"),
+        ShopType::AuctionHouse,
+        None,
+        None,
+        Localized::new(Language::En, Title::from("A vase")),
+        None,
+        None,
+        Default::default(),
+        None,
+        Default::default(),
+        None,
+        Default::default(),
+        ProductState::Listed,
+        Url::parse("https://shop.example.com/products/external").unwrap(),
+        Url::parse("https://aura.example.com/shops/shop-one/products/product-one").unwrap(),
+        [
+            ProductImage {
+                url: Url::parse("https://cdn.example.com/one.jpg").unwrap(),
+                prohibited_content: ProhibitedContent::Unknown,
+            },
+            ProductImage {
+                url: Url::parse("https://cdn.example.com/two.jpg").unwrap(),
+                prohibited_content: ProhibitedContent::Unknown,
+            },
+        ],
+        None,
+        None,
+    )
+}

--- a/src/product/tests/product_service_postgres.rs
+++ b/src/product/tests/product_service_postgres.rs
@@ -1,0 +1,158 @@
+use common::actor::domain::Actor;
+use common::language::domain::Language;
+use common::localized::Localized;
+use common::price::domain::FixedFxRate;
+use common::product_lifecycle::domain::ProductLifecycle;
+use common::product_state::domain::ProductState;
+use common::shop_id::ShopId;
+use common::shop_name::ShopName;
+use common::shop_slug_id::ShopSlugId;
+use common::shops_product_id::ShopsProductId;
+use fxrate::dynamodb::record::FxRatesRecord;
+use product::core::product_image::ProductImage;
+use product::core::prohibited_content::ProhibitedContent;
+use product::core::title::Title;
+use product::postgres::ProductPostgresRepository;
+use product::service::product_command::{CreateProductCommand, UpdateProductCommand};
+use product::service::product_service::{ProductService, ProductServiceImpl};
+use serial_test::serial;
+use shop::core::partner_status::ShopPartnerStatus;
+use shop::core::shop::Shop;
+use shop::core::shop_type::ShopType;
+use shop::service::get_service::MockGetShopService;
+use sqlx::PgPool;
+use std::collections::{HashMap, HashSet};
+use test_api::*;
+use time::OffsetDateTime;
+use url::Url;
+
+const BUSINESS_SCHEMA: Postgres = Postgres::new("migrations");
+
+#[serial]
+#[aura_integration_test(services = [BUSINESS_SCHEMA])]
+async fn should_facade_create_update_and_delete_product_in_postgres() {
+    let pool = get_postgres_client().await;
+    let shop_id = ShopId::new();
+    insert_shop(&pool, shop_id).await;
+    let repository = ProductPostgresRepository::new(pool.clone());
+    let shop_service = shop_service(shop_id);
+    let service = ProductServiceImpl::new_with_fx_rate(
+        &repository,
+        FxRatesRecord::from(FixedFxRate()),
+        &shop_service,
+    );
+    let key =
+        common::product_id::ProductKey::new(shop_id, ShopsProductId::from("external-service"));
+
+    let create_failures = service.create(vec![create_command(shop_id)]).await;
+    assert!(create_failures.is_empty());
+
+    let product = repository.get_product(&key).await.unwrap().unwrap();
+    assert_eq!(ProductState::Listed, product.state);
+
+    let mut updates = HashMap::new();
+    updates.insert(
+        key.clone(),
+        UpdateProductCommand {
+            state: Some(ProductState::Sold),
+            ..Default::default()
+        },
+    );
+    let update_failures = service.update(updates).await;
+    assert!(update_failures.is_empty());
+
+    let product = repository.get_product(&key).await.unwrap().unwrap();
+    assert_eq!(ProductState::Sold, product.state);
+
+    service.delete(&key).await.unwrap();
+
+    let product = repository.get_product(&key).await.unwrap().unwrap();
+    let events = repository
+        .list_events_for_product(product.product_id)
+        .await
+        .unwrap();
+    assert_eq!(ProductLifecycle::Deleted, product.lifecycle);
+    assert_eq!(3, events.len());
+    assert_eq!("DOMAIN_CREATED", events[0].event_type);
+    assert_eq!("DOMAIN_STATE_CHANGED", events[1].event_type);
+    assert_eq!("LIFECYCLE_DELETED", events[2].event_type);
+}
+
+fn shop_service(shop_id: ShopId) -> MockGetShopService {
+    let mut service = MockGetShopService::default();
+    service.expect_find_shop().returning(move |_| {
+        let shop = Shop {
+            shop_id,
+            shop_slug_id: ShopSlugId::from("Shop One"),
+            name: ShopName::from("Shop One"),
+            shop_type: ShopType::AuctionHouse,
+            domains: HashSet::new(),
+            shopify_domain: None,
+            shopify_currency: None,
+            shopify_language: None,
+            woocommerce_webhook_secret: None,
+            woocommerce_currency: None,
+            woocommerce_language: None,
+            url: None,
+            view_url: None,
+            image: None,
+            structured_address: None,
+            geo_address: None,
+            phone: None,
+            email: None,
+            partner_status: ShopPartnerStatus::Partnered,
+            affiliate_configuration: None,
+            created_by: Actor::System,
+            updated_by: Actor::System,
+            created: OffsetDateTime::now_utc(),
+            updated: OffsetDateTime::now_utc(),
+        };
+        Box::pin(async move { Ok(shop) })
+    });
+    service
+}
+
+async fn insert_shop(pool: &PgPool, shop_id: ShopId) {
+    sqlx::query(
+        "INSERT INTO shops (shop_id, shop_slug_id, name, shop_type, partner_status, created_by, updated_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(uuid::Uuid::from(shop_id))
+    .bind(format!("shop-{shop_id}"))
+    .bind("Shop One")
+    .bind("AUCTION_HOUSE")
+    .bind("PARTNERED")
+    .bind("SYSTEM")
+    .bind("SYSTEM")
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn create_command(shop_id: ShopId) -> CreateProductCommand {
+    CreateProductCommand {
+        shop_id,
+        shops_product_id: ShopsProductId::from("external-service"),
+        seller_name_raw: None,
+        structured_address: None,
+        geo_address: None,
+        native_title: Localized::new(Language::En, Title::from("A vase")),
+        other_title: HashMap::new(),
+        native_description: None,
+        native_price: None,
+        other_price: HashMap::new(),
+        native_price_estimate_min: None,
+        other_price_estimate_min: HashMap::new(),
+        native_price_estimate_max: None,
+        other_price_estimate_max: HashMap::new(),
+        state: ProductState::Listed,
+        url: Url::parse("https://shop.example.com/products/external-service").unwrap(),
+        images: [ProductImage {
+            url: Url::parse("https://cdn.example.com/service.jpg").unwrap(),
+            prohibited_content: ProhibitedContent::Unknown,
+        }]
+        .into(),
+        auction_start: None,
+        auction_end: None,
+    }
+}


### PR DESCRIPTION
Closes #1378
Closes #1379
Parent: #1341

## Intent

Add the Postgres product write path for the Hetzner migration with one Postgres repository and one product service facade. Callers should use domain types and not know about Postgres rows or DynamoDB records.

## Summary

- Adds `product::postgres::ProductPostgresRepository` as the single Postgres product data-source repository.
- Removes DynamoDB `ProductRecord` / `ProductEventRecord` usage from the Postgres path.
- Removes `ProductPostgresWriteService`; write orchestration now lives in `product::service::product_service`.
- Adds `ProductService` facade for create/update/upsert/delete backed by Postgres and domain events.
- Persists `products` and `product_events` transactionally with optimistic `products.event_id` checks.
- Stores inline `product_images` JSON in order.
- Stores product event payload JSON from domain events, not raw DynamoDB transport records.
- Adds Postgres integration tests for repository and facade create/update/delete flows.

## Breaking changes

- New Postgres path no longer depends on the `dynamodb` feature.
- Legacy DynamoDB command/get/query/semantic services still exist for old callers while API/runtime wiring migrates.

## Behavior impact

- Product write callers can now use a single product service facade for synchronous Postgres writes.
- Create/update/delete write product materialized state and product events in one Postgres transaction.
- Sequin can consume committed product/product-event rows after the transaction.

## Risk

- Main risk is product field-mapping drift between domain and Postgres columns. Mitigated with repository round-trip tests and facade create/update/delete integration test.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p product --features postgres`
- `cargo check -p product --all-features`
- `cargo test -p product --features postgres --lib`
- `cargo test -p product --features postgres --test product_postgres_repository`
- `cargo test -p product --all-features --test product_service_postgres`
- `cargo clippy -p product --lib --all-features -- -D warnings`
- `cargo test -p product --all-features`

## Notes

- `cargo clippy -p product --all-targets --all-features -- -D warnings` is blocked by pre-existing `test-api` dead code warning at `src/test-api/src/opensearch.rs:119`.
